### PR TITLE
Add the API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Blue Link Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ You can think of it as a souped-up RSS: users publish records as files on their 
 
 New to dat? [Read this quick primer.](./dat-primer.md)
 
+## API
+
+[Read the API docs here](./api.md).
+
+```js
+import {feed, followgraph} from 'dat://unwalled.garden'
+
+await feed.addPost({content: {body: 'Hello, world!'}})
+await followgraph.follow('dat://beakerbrowser.com')
+```
+
+Requires [Beaker browser 0.9+](https://beakerbrowser.com).
+
 ## File structure
 
 ```

--- a/api.md
+++ b/api.md
@@ -1,0 +1,160 @@
+# API
+
+The Unwalled.Garden API is an accessible toolkit for building social apps.
+
+Requires [Beaker browser 0.9+](https://beakerbrowser.com).
+
+```js
+import {feed, followgraph} from 'dat://unwalled.garden'
+
+feed.query({
+  filters: {authors},
+  offset,
+  limit,
+  reverse
+})
+feed.getPost(postUrl)
+feed.addPost({content: {body}})
+feed.editPost(postUrl, {content: {body}})
+feed.deletePost(postUrl)
+
+followgraph.listFollowers(siteUrl, {filters: {followedBy}, limit, offset})
+followgraph.listFollows(siteUrl, {filters: {followedBy}, limit, offset})
+followgraph.isAFollowingB(siteUrlA, siteUrlB)
+followgraph.follow(siteUrl)
+followgraph.unfollow(siteUrl)
+```
+
+## `feed`
+
+### `FeedPost`
+
+The values returned by feed functions will fit the following object shape:
+
+  - `url` string - The URL of the post.
+  - `content` Object
+    - `body` string - The text body of the post. Limited to 280 characters in length.
+  - `crawledAt` number - The timestamp of when this post was crawled by the user's computer.
+  - `createdAt` number - The timestamp of when the post claims it was created. (May be wrong.)
+  - `updatedAt` number - The timestamp of when the post claims it was last updated. (May be wrong.)
+  - `author` Object - The post author's information.
+    - `url` string
+    - `title` string
+    - `description` string
+    - `type` string[]
+
+### `feed.query(opts)`
+
+Get a list of posts, ordered by the posts' claimed creation dates.
+
+  - `opts` Object
+    - `filters` Object
+      - `authors` string|string[] - A URL or set of URLs of authors to filter the feed down to.
+    - `offset=0` number
+    - `limit` number
+    - `reverse` boolean
+  - Returns `Promise<FeedPost[]>`
+
+By default, all crawled posts will be included in the output. If you want to only show posts by sites that the user follows, use the `followgraph` API to get the followed sites and pass their URLs into the `authors` filter.
+
+### `feed.getPost(postUrl)`
+
+Get an individual post by its URL.
+
+  - `postUrl` string - The URL of the post you want to read.
+  - Returns `Promise<FeedPost>`
+
+### `feed.addPost(post)`
+
+Add a post to the current user's site.
+
+  - `post` Object
+    - `content` Object
+      - `body` string - The text body of the post. Limited to 280 characters in length.
+  - Returns `Promise<FeedPost>`
+
+Example usage:
+
+```js
+var myPost = await feed.addPost({content: {body: 'Hello, world!'}})
+```
+
+### `feed.editPost(postUrl, post)`
+
+Edit a post on the current user's site.
+
+  - `postUrl` string - The URL of the post you want to edit.
+  - `post` Object
+    - `content` Object
+      - `body` string - The text body of the post. Limited to 280 characters in length.
+  - Returns `Promise<FeedPost>`
+
+Example usage:
+
+```js
+myPost = await feed.addPost(myPost.url, {content: {body: 'Hello, world!!'}})
+```
+
+### `feed.deletePost(postUrl)`
+
+Delete a post on the current user's site.
+
+  - `postUrl` string - The URL of the post you want to delete.
+  - Returns `Promise<void>`
+
+## `followgraph`
+
+### `Site`
+
+The values returned by followgraph functions will fit the following object shape:
+
+  - `url` string
+  - `title` string
+  - `description` string
+  - `type` string[]
+
+### `followgraph.listFollowers(siteUrl, opts)`
+
+List the sites known to follow the given URL. (Will only include sites which have been crawled by the local user.)
+
+  - `siteUrl` string - The URL of the site to get followers of.
+  - `opts` Object
+    - `filters` Object
+      - `followedBy` string - Filters the results to sites which are followed by this URL.
+    - `offset` number
+    - `limit` number
+  - Returns `Promise<Site[]>`
+
+### `followgraph.listFollows(siteUrl, opts)`
+
+List the sites followed by the given URL.
+
+  - `siteUrl` string - The URL of the site to get follows of.
+  - `opts` Object
+    - `filters` Object
+      - `followedBy` string - Filters the results to sites which are followed by this URL.
+    - `offset` number
+    - `limit` number
+  - Returns `Promise<Site[]>`
+
+### `followgraph.isAFollowingB(siteUrlA, siteUrlB)`
+
+Checks whether one site follows the other.
+
+  - `siteUrlA` string - The URL of the site which will have its "follows" queried.
+  - `siteUrlB` string - The URL of the site which will be looked for in the "follows."
+  - Returns `Promise<boolean>`
+
+### `followgraph.follow(siteUrl)`
+
+Add a follow to the current user's site.
+
+  - `siteUrl` string - The URL of the site to follow.
+  - Returns `Promise<void>`
+
+### `followgraph.unfollow(siteUrl)`
+
+Remove a follow from the current user's site.
+
+  - `siteUrl` string - The URL of the site to unfollow.
+  - Returns `Promise<void>`

--- a/index.js
+++ b/index.js
@@ -1,0 +1,39 @@
+/**
+ * Unwalled.Garden API shim (v1)
+ * © Copyright Blue Link Labs 2019
+ * 
+ * ## Example usage:
+ * 
+ * import {feed, followgraph} from 'dat://unwalled.garden'
+ *
+ * feed.addPost({content: {body: 'Hello, world!'}})
+ * followgraph.follow('dat://beakerbrowser.com')
+ *
+ * ## What is this?
+ * 
+ * This module is a thin wrapper around Beaker browser's builtin APIs.
+ * It requires Beaker browser v0.9+ to work.
+ *
+ * ## Why does this exist?
+ * 
+ * The Web platform community is still deciding how to build a "standard
+ * library" which can be imported by ES modules. As part of the Extensible
+ * Web Manifesto, a goal for an stdlib is to use shim solutions which can
+ * smoothly upgrade to native Web APIs if/when they are adopted. In that
+ * spirit, the Beaker team wanted a solution for its new Web APIs that
+ * wasn't just a new set of builtin global objects. By wrapping the
+ * `navigator.importSystemAPI()` call in this shim, we gave ourselves some
+ * freedom to adopt the future stdlib solutions.
+ * 
+ * ## Why are these APIs implemented in the browser?
+ * 
+ * The existing Web APIs for running unwalled.garden's database are
+ * not suitable enough for our goals. We gave it a shot (see
+ * https://github.com/beakerbrowser/libfritter) and found that indexeddb
+ * couldn't perform the way we needed. Rather than try to create new
+ * database primitives, we decided to build high-level APIs into the
+ * browser directly. By having consumers import from this wrapper, we left
+ * open the possibility that these APIs could move into userland.
+ */
+export const feed = navigator.importSystemAPI('unwalled-garden-feed')
+export const followgraph = navigator.importSystemAPI('unwalled-garden-followgraph')

--- a/slugify-url.js
+++ b/slugify-url.js
@@ -1,6 +1,6 @@
 var reservedChars = /[<>:"\/\\|?*\x00-\x1F]/g
 
-function slugifyUrl (str) {
+export function slugifyUrl (str) {
   try {
     let url = new URL(str)
     str = url.hostname + url.pathname + url.search + url.hash


### PR DESCRIPTION
This PR adds a Web API. In reality, the API module (index.js) is a thin wrapper around Beaker's builtins. Here is the explanation included in the file's header:

> ## Why does this exist?
> 
> The Web platform community is still deciding how to build a "standard
> library" which can be imported by ES modules. As part of the Extensible
> Web Manifesto, a goal for an stdlib is to use shim solutions which can
> smoothly upgrade to native Web APIs if/when they are adopted. In that
> spirit, the Beaker team wanted a solution for its new Web APIs that
> wasn't just a new set of builtin global objects. By wrapping the
> `navigator.importSystemAPI()` call in this shim, we gave ourselves some
> freedom to adopt the future stdlib solutions.
> 
> ## Why are these APIs implemented in the browser?
> 
> The existing Web APIs for running unwalled.garden's database are
> not suitable enough for our goals. We gave it a shot (see
> https://github.com/beakerbrowser/libfritter) and found that indexeddb
> couldn't perform the way we needed. Rather than try to create new
> database primitives, we decided to build high-level APIs into the
> browser directly. By having consumers import from this wrapper, we left
> open the possibility that these APIs could move into userland.