### PR TITLE
Bookmark schema tweaks

### DIFF
--- a/bookmark.json
+++ b/bookmark.json
@@ -32,8 +32,11 @@
           "maxLength": 560
         },
         "tags": {
-          "type": "string",
-          "maxLength": 280
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 100
+          }
         }
       }
     },

--- a/bookmark.json
+++ b/bookmark.json
@@ -20,7 +20,8 @@
           "format": "uri",
           "examples": [
             "dat://beakerbrowser.com"
-          ]
+          ],
+          "maxLength": 10000
         },
         "title": {
           "type": "string",

--- a/bookmark.md
+++ b/bookmark.md
@@ -18,7 +18,7 @@ Example link:
     "href": "dat://beakerbrowser.com",
     "title": "Beaker Browser",
     "description": "An experimental peer-to-peer Web browser by Paul Frazee. Built using the dat protocol.",
-    "tags": "p2p web dat"
+    "tags": ["p2p", "web", "dat"]
   },
   "createdAt": "2018-12-07T02:52:11.947Z"
 }


### PR DESCRIPTION
- Set a max length on the href (10k characters)
- Make the `tags` attribute an array of strings so that it's easier to interpret