### PR TITLE
Update the reaction schema to support multiple emojis

### DIFF
--- a/reaction.json
+++ b/reaction.json
@@ -7,7 +7,7 @@
   "required": [
     "type",
     "topic",
-    "content"
+    "emojis"
   ],
   "properties": {
     "type": {
@@ -23,9 +23,12 @@
         "dat://beakerbrowser.com"
       ]
     },
-    "content": {
-      "type": "string",
-      "description": "The reaction emoji. Must be a supported emoji."
+    "emojis": {
+      "type": "array",
+      "description": "The reaction emojis. Must contain supported emojis.",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false

--- a/reaction.md
+++ b/reaction.md
@@ -7,7 +7,7 @@
 
 Reactions are emojis which users attach to content. They are a more general form of a "like." They have minimal semantic meaning, though the emojis could easily be categorized for sentiment.
 
-The full list of supported emoji code-points can be found at [supported-reaction-emojis.json](./supported-reaction-emojis.json). All skin-tone variants of that listing should be supported as well. Emojis which are not found in that list must be ignored.
+The full list of supported emoji code-points can be found at [supported-reaction-emojis.json](./supported-reaction-emojis.json). All skin-tone variants of that listing should be supported as well. Emojis which are not found in that list should be ignored.
 
 Reactions are published as a filename which is the slugified URL of the topic. You can find the algorithm for slugifying URLs in [slugify-url.js](./slugify-url.js).
 
@@ -17,6 +17,6 @@ A standard reaction:
 {
   "type": "unwalled.garden/reaction",
   "topic": "dat://beakerbrowser.com/",
-  "content": "👍"
+  "emojis": ["👍", "🔥"]
 }
 ```


### PR DESCRIPTION
Users can attach multiple reactions to a resource. Needed to change the schema to support that. (Also decided to rename the `"content"` key to `"emojis"`.)