### PR TITLE
Expanded site types and recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Requires [Beaker browser 0.9+](https://beakerbrowser.com).
 /data/follows.json      - An unwalled.garden/follows record
 /data/posts/            - Contains unwalled.garden/post records
 /data/reactions/        - Contains unwalled.garden/reaction records
+/data/recommendations/  - Contains unwalled.garden/recommendation records
 /data/comments/         - Contains unwalled.garden/comment records
 /data/votes/            - Contains vote records (see "the votes folder")
 /data/known-sites/      - Contains cached copies of referenced sites' metadata
@@ -49,6 +50,7 @@ Requires [Beaker browser 0.9+](https://beakerbrowser.com).
    - [Follows](./follows.md) `unwalled.garden/follows`
    - [Post](./post.md) `unwalled.garden/post`
    - [Reaction](./reaction.md) `unwalled.garden/reaction`
+   - [Recommendation](./recommendation.md) `unwalled.garden/recommendation`
 
 ## Folder patterns
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ Requires [Beaker browser 0.9+](https://beakerbrowser.com).
    - [Reaction](./reaction.md) `unwalled.garden/reaction`
    - [Recommendation](./recommendation.md) `unwalled.garden/recommendation`
 
+## Site-type listing
+
+ - Users
+   - [Person](./person.md) `unwalled.garden/person`
+ - Media
+   - [Website](./website.md) `unwalled.garden/website`
+ - Software
+   - [Application](./application.md) `unwalled.garden/application`
+   - [Module](./module.md) `unwalled.garden/module`
+
 ## Folder patterns
 
 ### The posts folder

--- a/application.md
+++ b/application.md
@@ -1,0 +1,5 @@
+# Application
+
+ - Site
+ - Description: An installable Web application which can integrate into the browser's toolset.
+ - Schema: `unwalled.garden/application`

--- a/module.md
+++ b/module.md
@@ -1,0 +1,5 @@
+# Module
+
+ - Site
+ - Description: A bundle of code.
+ - Schema: `unwalled.garden/module`

--- a/person.md
+++ b/person.md
@@ -1,0 +1,5 @@
+# Person
+
+ - Site
+ - Description: A human user on the network.
+ - Schema: `unwalled.garden/person`

--- a/recommendation.json
+++ b/recommendation.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/recommendation.json",
+  "type": "object",
+  "title": "Recommendation",
+  "description": "A broadcasted recommendation for some resource.",
+  "required": [
+    "type",
+    "category",
+    "href"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The object's type",
+      "const": "unwalled.garden/recommendation"
+    },
+    "category": {
+      "type": "string",
+      "description": "What kind of resource is being recommended",
+      "examples": [
+        "unwalled.garden/website"
+      ]
+    },
+    "href": {
+      "type": "string",
+      "description": "What resource is being recommended",
+      "format": "uri",
+      "examples": [
+        "dat://beakerbrowser.com"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/recommendation.md
+++ b/recommendation.md
@@ -1,0 +1,27 @@
+### Recommendation
+
+ - JSON Record
+ - Description: A broadcasted recommendation for some resource.
+ - Schema: [`unwalled.garden/recommendation`](./recommendation.json)
+ - Path: `/data/recommendations/{slugified-href}.json`
+
+Recommendations are pointers to resources which the author thinks is worth seeing or using.
+
+The `"category"` field should be a resource-type URL. Examples include:
+
+ - [`unwalled.garden/website`](./website.md)
+ - [`unwalled.garden/application`](./application.md)
+ - [`unwalled.garden/person`](./person.md)
+ - [`unwalled.garden/post`](./post.md)
+ - ['unwalled.garden/comment`](./comment.md)
+
+Example recommendation for an application:
+
+```json
+{
+  "type": "unwalled.garden/recommendation",
+  "category": "unwalled.garden/application",
+  "href": "dat://beaker.social",
+  "createdAt": "2018-12-07T02:52:11.947Z"
+}
+```

--- a/website.md
+++ b/website.md
@@ -1,0 +1,5 @@
+# Website
+
+ - Site
+ - Description: A general-purpose website.
+ - Schema: `unwalled.garden/website`


### PR DESCRIPTION
This PR re-introduces site types which are specified in the `dat.json` "type" field. It includes 4 starting site types:

 - Application
 - Module
 - Person
 - Website

This PR also introduces the `recommendation` json-record type which is used to broadcast recommended content to the network.