### PR TITLE
Relationships

### DIFF
--- a/_md/dir/data.md
+++ b/_md/dir/data.md
@@ -17,3 +17,4 @@
 |`/follows.json`|[Follows](/follows)|
 |`/posts/*.json`|[Post](/post)|
 |`/reactions/*.json`|[Reaction](/reaction)|
+|`/relationships/*.json`|[Relationship](/relationship)|

--- a/_md/docs/api/relationships.md
+++ b/_md/docs/api/relationships.md
@@ -1,0 +1,212 @@
+## Relationships API
+
+Relationships are declarations of a linkage between two resources on the Web. They can be used to declare things such as "Alice is the spouse of Bob" and "Carla is an employee of Foo Inc."
+
+The records take the shape of `{a, rel, b}`. The way to read relationships is as follows:
+
+```
+{a} is a/an/the {rel} of/to/about/with {b}
+```
+
+For instance, the following record:
+
+```json
+{
+  "type": "unwalled.garden/relationship",
+  "a": "dat://alice.com",
+  "rel": "spouse",
+  "b": "dat://bob.com",
+  "createdAt": "2018-12-07T02:52:11.947Z"
+}
+```
+
+Should be read as:
+
+
+```
+dat://alice.com is the spouse of dat://bob.com
+```
+
+The `rel` field may be any alphanumeric string. Here are some suggested values:
+
+ - Friends
+   - `"acquaintance"`
+   - `"friend"`
+   - `"significantOther"`
+   - `"neighbor"`
+ - Enemies
+   - `"antagonist"`
+   - `"critic"`
+   - `"enemy"`
+   - `"hater"`
+   - `"rival"`
+   - `"suspicious"`
+ - Events
+   - `"attendee"`
+   - `"participant"`
+ - Family
+   - `"ancestor"`
+   - `"child"`
+   - `"descendant"`
+   - `"engaged"`
+   - `"grandchild"`
+   - `"grandparent"`
+   - `"lifePartner"`
+   - `"parent"`
+   - `"sibling"`
+   - `"spouse"`
+ - Projects
+   - `"alternative"`
+   - `"author"`
+   - `"competitor"`
+   - `"contributor"`
+   - `"creator"`
+   - `"designer"`
+   - `"evangelist"`
+   - `"fan"`
+   - `"founder"`
+   - `"implementor"`
+   - `"inspiration"`
+   - `"passionate"`
+   - `"promoter"`
+   - `"supporter"`
+   - `"user"`
+ - Work
+   - `"advisor"`
+   - `"apprentice"`
+   - `"collaborator"`
+   - `"colleague"`
+   - `"employer"`
+   - `"funder"`
+   - `"mentor"`
+
+---
+
+```js
+import {relationships} from 'dat://unwalled.garden/index.js'
+
+// read
+await relationships.list({
+  filters: {authors, as, rels, bs, visiblity},
+  sortBy,
+  offset,
+  limit,
+  reverse
+})
+await relationships.get(url)
+
+// write
+await relationships.add({a, rel, b, visibility})
+await relationships.edit(url, {a, rel, b, visibility})
+await relationships.delete(url)
+```
+
+---
+
+### Relationship
+
+The values returned by relationship functions will fit the following object shape:
+
+|Attribute|Type|Usage|
+|-|-|-|
+|url|`string`|The URL of the relationship record|
+|a|`string`|The URL that's the "object" of the relationship|
+|rel|`string`|The ID of the relationship|
+|b|`string`|The URL that's the "subject" of the relationship|
+|author</var>|`Object`|The site that authored the relationship|
+|&emsp;url</var>|`string`||
+|&emsp;title</var>|`string`||
+|&emsp;description</var>|`string`||
+|&emsp;type</var>|`string[]`||
+|visibility</var>|`string`|The [visibility](/docs/common-fields#visibility) of the relationship|
+
+---
+
+### list(opts)
+
+List the relationships on the network.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|opts|`Object`|||
+|&emsp;filters|`Object`|||
+|&emsp;&emsp;authors|`string|string[]`||Site URLs|
+|&emsp;&emsp;as|`string|string[]`||URLs|
+|&emsp;&emsp;rels|`string|string[]`||Relationship IDs|
+|&emsp;&emsp;bs|`string|string[]`||URLs|
+|&emsp;&emsp;visibility|`string`|`'all'`|See [visibility](/docs/common-fields#visibility)|
+|&emsp;sortBy|`string`|`'createdAt'`|One of: `'createdAt'`|
+|&emsp;offset|`number`|0||
+|&emsp;limit|`number`|||
+|&emsp;reverse|`boolean`|`false`||
+
+|Returns|
+|-|
+|`Promise<Relationship[]>`|
+
+---
+
+### get(url)
+
+Get an individual relationship by its URL.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|url|`string`||Relationship URL (required)|
+
+|Returns|
+|-|
+|`Promise<Relationship>`|
+
+---
+
+### add(relationship)
+
+Add a relationship to the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|relationship|`Object`|||
+|&emsp;a|`string`||The URL of the "object" of the relationship (required)|
+|&emsp;rel|`string`||The ID of the relationship (required)|
+|&emsp;b|`string`||The URL of the "subject" of the relationship (required)|
+|&emsp;visibility|`string`|`'public'`|See [visibility](/docs/common-fields#visibility)|
+
+|Returns|
+|-|
+|`Promise<Relationship>`|
+
+---
+
+### edit(url, relationship)
+
+Edit a relationship on the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|url|`string`||The URL of the relationship you want to edit (required)|
+|relationship|`Object`|||
+|&emsp;a|`string`||The URL of the "object" of the relationship|
+|&emsp;rel|`string`||The ID of the relationship|
+|&emsp;b|`string`||The URL of the "subject" of the relationship|
+|&emsp;visibility|`string`|`'public'`|See [visibility](/docs/common-fields#visibility)|
+
+|Returns|
+|-|
+|`Promise<Relationship>`|
+
+---
+
+### delete(url)
+
+Delete a relationship on the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|url|`string`||The URL of the relationship you want to delete (required)|
+
+|Returns|
+|-|
+|`Promise<void>`|
+
+---

--- a/_md/relationship.md
+++ b/_md/relationship.md
@@ -1,0 +1,146 @@
+## Relationship `unwalled.garden/relationship`
+
+---
+
+ - File type
+ - **Description**: A declared relationship between two resources.
+ - **Path**: `/.data/unwalled.garden/relationships/*.json`
+
+---
+
+#### Notes
+
+The way to read relationships is as follows:
+
+```
+{a} is a/an/the {rel} of/to/about/with {b}
+```
+
+For instance, the following record:
+
+```json
+{
+  "type": "unwalled.garden/relationship",
+  "a": "dat://alice.com",
+  "rel": "spouse",
+  "b": "dat://bob.com",
+  "createdAt": "2018-12-07T02:52:11.947Z"
+}
+```
+
+Should be read as:
+
+
+```
+dat://alice.com is the spouse of dat://bob.com
+```
+
+The `rel` field may be any alphanumeric string. Here are some suggested values:
+
+ - Friends
+   - `"acquaintance"`
+   - `"friend"`
+   - `"significantOther"`
+   - `"neighbor"`
+ - Enemies
+   - `"antagonist"`
+   - `"critic"`
+   - `"enemy"`
+   - `"hater"`
+   - `"rival"`
+   - `"suspicious"`
+ - Events
+   - `"attendee"`
+   - `"participant"`
+ - Family
+   - `"ancestor"`
+   - `"child"`
+   - `"descendant"`
+   - `"engaged"`
+   - `"grandchild"`
+   - `"grandparent"`
+   - `"lifePartner"`
+   - `"parent"`
+   - `"sibling"`
+   - `"spouse"`
+ - Projects
+   - `"alternative"`
+   - `"author"`
+   - `"competitor"`
+   - `"contributor"`
+   - `"creator"`
+   - `"designer"`
+   - `"evangelist"`
+   - `"fan"`
+   - `"founder"`
+   - `"implementor"`
+   - `"inspiration"`
+   - `"passionate"`
+   - `"promoter"`
+   - `"supporter"`
+   - `"user"`
+ - Work
+   - `"advisor"`
+   - `"apprentice"`
+   - `"collaborator"`
+   - `"colleague"`
+   - `"employer"`
+   - `"funder"`
+   - `"mentor"`
+
+#### Examples
+
+```json
+{
+  "type": "unwalled.garden/relationship",
+  "a": "dat://alice.com",
+  "rel": "spouse",
+  "b": "dat://bob.com",
+  "createdAt": "2018-12-07T02:52:11.947Z"
+}
+```
+
+#### Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/relationship.json",
+  "type": "object",
+  "title": "Relationship",
+  "description": "A declared relationship between two resources.",
+  "required": [
+    "type",
+    "a",
+    "rel",
+    "b",
+    "createdAt"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "unwalled.garden/relationship"
+    },
+    "a": {
+      "type": "string",
+      "format": "uri"
+    },
+    "rel": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]*$"
+    },
+    "b": {
+      "type": "string",
+      "format": "uri"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}
+```

--- a/application.html
+++ b/application.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/assets/nav.html
+++ b/assets/nav.html
@@ -20,6 +20,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -32,6 +33,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/bookmark.html
+++ b/bookmark.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/comment.html
+++ b/comment.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/dir/data.html
+++ b/dir/data.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>
@@ -100,6 +102,10 @@
 <tr>
 <td><code>/reactions/*.json</code></td>
 <td><a href="/reaction">Reaction</a></td>
+</tr>
+<tr>
+<td><code>/relationships/*.json</code></td>
+<td><a href="/relationship">Relationship</a></td>
 </tr>
 </tbody>
 </table>

--- a/dir/refs.html
+++ b/dir/refs.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/bookmarks.html
+++ b/docs/api/bookmarks.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/comments.html
+++ b/docs/api/comments.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/follows.html
+++ b/docs/api/follows.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/posts.html
+++ b/docs/api/posts.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/profiles.html
+++ b/docs/api/profiles.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/reactions.html
+++ b/docs/api/reactions.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/relationships.html
+++ b/docs/api/relationships.html
@@ -1,0 +1,531 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Relationships API | Unwalled.Garden</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="/assets/styles.css">
+    <link rel="stylesheet" href="/assets/syntax.css">
+  </head>
+  <body>
+    <h1><a href="/">Unwalled.Garden</a></h1>
+    <a class="nav-open"><img src="/assets/hamburger.svg"></a>
+    <div class="notice">Status: DRAFT. Part of the upcoming <a href="https://beakerbrowser.com">Beaker Browser</a> 0.9 release.</div>
+    <div class="page">
+      <nav>
+        <a class="nav-close"><img src="/assets/hamburger.svg"></a>
+        <ul>
+    <li>Docs
+      <ul>
+        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/dat-primer">Dat protocol</a><ul>
+          <li><a href="/docs/mounts">Mounts</a></li>
+        </ul></li>
+        <li><a href="/docs/browser-integration">Browser integration</a></li>
+        <li><a href="/docs/common-fields">Common fields</a></li>
+        <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
+      </ul>
+    </li>
+  </ul>
+<ul>
+  <li>APIs
+    <ul>
+      <li><a href="/docs/api/bookmarks">Bookmarks</a></li>
+      <li><a href="/docs/api/comments">Comments</a></li>
+      <li><a href="/docs/api/follows">Follows</a></li>
+      <li><a href="/docs/api/posts">Posts</a></li>
+      <li><a href="/docs/api/profiles">Profiles</a></li>
+      <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Schemas
+    <ul>
+      <li><a href="/bookmark">Bookmark</a></li>
+      <li><a href="/comment">Comment</a></li>
+      <li><a href="/follows">Follows</a></li>
+      <li><a href="/person">Person</a></li>
+      <li><a href="/post">Post</a></li>
+      <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
+      <li>dir<ul>
+        <li><a href="/dir/data">Data</a></li>
+        <li><a href="/dir/refs">Refs</a></li>
+      </ul></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Links
+    <ul>
+      <li><a href="https://github.com/beakerbrowser/unwalled.garden">Github Repo</a></li>
+      <li><a href="https://beakerbrowser.com">Beaker Browser</a></li>
+      <li><a href="https://dat.foundation">Dat protocol</a></li>
+    </ul>
+  </li>
+</ul>
+      </nav>
+      <main><h2>Relationships API</h2>
+<p>Relationships are declarations of a linkage between two resources on the Web. They can be used to declare things such as “Alice is the spouse of Bob” and “Carla is an employee of Foo Inc.”</p>
+<p>The records take the shape of <code>{a, rel, b}</code>. The way to read relationships is as follows:</p>
+<pre><code>{a} is a/an/the {rel} of/to/about/with {b}
+</code></pre>
+<p>For instance, the following record:</p>
+<pre><code class="language-json">{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/relationship"</span>,
+  <span class="hljs-attr">"a"</span>: <span class="hljs-string">"dat://alice.com"</span>,
+  <span class="hljs-attr">"rel"</span>: <span class="hljs-string">"spouse"</span>,
+  <span class="hljs-attr">"b"</span>: <span class="hljs-string">"dat://bob.com"</span>,
+  <span class="hljs-attr">"createdAt"</span>: <span class="hljs-string">"2018-12-07T02:52:11.947Z"</span>
+}
+</code></pre>
+<p>Should be read as:</p>
+<pre><code>dat://alice.com is the spouse of dat://bob.com
+</code></pre>
+<p>The <code>rel</code> field may be any alphanumeric string. Here are some suggested values:</p>
+<ul>
+<li>Friends
+<ul>
+<li><code>&quot;acquaintance&quot;</code></li>
+<li><code>&quot;friend&quot;</code></li>
+<li><code>&quot;significantOther&quot;</code></li>
+<li><code>&quot;neighbor&quot;</code></li>
+</ul>
+</li>
+<li>Enemies
+<ul>
+<li><code>&quot;antagonist&quot;</code></li>
+<li><code>&quot;critic&quot;</code></li>
+<li><code>&quot;enemy&quot;</code></li>
+<li><code>&quot;hater&quot;</code></li>
+<li><code>&quot;rival&quot;</code></li>
+<li><code>&quot;suspicious&quot;</code></li>
+</ul>
+</li>
+<li>Events
+<ul>
+<li><code>&quot;attendee&quot;</code></li>
+<li><code>&quot;participant&quot;</code></li>
+</ul>
+</li>
+<li>Family
+<ul>
+<li><code>&quot;ancestor&quot;</code></li>
+<li><code>&quot;child&quot;</code></li>
+<li><code>&quot;descendant&quot;</code></li>
+<li><code>&quot;engaged&quot;</code></li>
+<li><code>&quot;grandchild&quot;</code></li>
+<li><code>&quot;grandparent&quot;</code></li>
+<li><code>&quot;lifePartner&quot;</code></li>
+<li><code>&quot;parent&quot;</code></li>
+<li><code>&quot;sibling&quot;</code></li>
+<li><code>&quot;spouse&quot;</code></li>
+</ul>
+</li>
+<li>Projects
+<ul>
+<li><code>&quot;alternative&quot;</code></li>
+<li><code>&quot;author&quot;</code></li>
+<li><code>&quot;competitor&quot;</code></li>
+<li><code>&quot;contributor&quot;</code></li>
+<li><code>&quot;creator&quot;</code></li>
+<li><code>&quot;designer&quot;</code></li>
+<li><code>&quot;evangelist&quot;</code></li>
+<li><code>&quot;fan&quot;</code></li>
+<li><code>&quot;founder&quot;</code></li>
+<li><code>&quot;implementor&quot;</code></li>
+<li><code>&quot;inspiration&quot;</code></li>
+<li><code>&quot;passionate&quot;</code></li>
+<li><code>&quot;promoter&quot;</code></li>
+<li><code>&quot;supporter&quot;</code></li>
+<li><code>&quot;user&quot;</code></li>
+</ul>
+</li>
+<li>Work
+<ul>
+<li><code>&quot;advisor&quot;</code></li>
+<li><code>&quot;apprentice&quot;</code></li>
+<li><code>&quot;collaborator&quot;</code></li>
+<li><code>&quot;colleague&quot;</code></li>
+<li><code>&quot;employer&quot;</code></li>
+<li><code>&quot;funder&quot;</code></li>
+<li><code>&quot;mentor&quot;</code></li>
+</ul>
+</li>
+</ul>
+<hr>
+<pre><code class="language-js"><span class="hljs-keyword">import</span> {relationships} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
+
+<span class="hljs-comment">// read</span>
+<span class="hljs-keyword">await</span> relationships.list({
+  <span class="hljs-attr">filters</span>: {authors, <span class="hljs-keyword">as</span>, rels, bs, visiblity},
+  sortBy,
+  offset,
+  limit,
+  reverse
+})
+<span class="hljs-keyword">await</span> relationships.get(url)
+
+<span class="hljs-comment">// write</span>
+<span class="hljs-keyword">await</span> relationships.add({a, rel, b, visibility})
+<span class="hljs-keyword">await</span> relationships.edit(url, {a, rel, b, visibility})
+<span class="hljs-keyword">await</span> relationships.delete(url)
+</code></pre>
+<hr>
+<h3>Relationship</h3>
+<p>The values returned by relationship functions will fit the following object shape:</p>
+<table>
+<thead>
+<tr>
+<th>Attribute</th>
+<th>Type</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>url</td>
+<td><code>string</code></td>
+<td>The URL of the relationship record</td>
+</tr>
+<tr>
+<td>a</td>
+<td><code>string</code></td>
+<td>The URL that’s the “object” of the relationship</td>
+</tr>
+<tr>
+<td>rel</td>
+<td><code>string</code></td>
+<td>The ID of the relationship</td>
+</tr>
+<tr>
+<td>b</td>
+<td><code>string</code></td>
+<td>The URL that’s the “subject” of the relationship</td>
+</tr>
+<tr>
+<td>author</var></td>
+<td><code>Object</code></td>
+<td>The site that authored the relationship</td>
+</tr>
+<tr>
+<td> url</var></td>
+<td><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td> title</var></td>
+<td><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td> description</var></td>
+<td><code>string</code></td>
+<td></td>
+</tr>
+<tr>
+<td> type</var></td>
+<td><code>string[]</code></td>
+<td></td>
+</tr>
+<tr>
+<td>visibility</var></td>
+<td><code>string</code></td>
+<td>The <a href="/docs/common-fields#visibility">visibility</a> of the relationship</td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>list(opts)</h3>
+<p>List the relationships on the network.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>opts</td>
+<td><code>Object</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td> filters</td>
+<td><code>Object</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td>  authors</td>
+<td><code>string|string[]</code></td>
+<td></td>
+<td>Site URLs</td>
+</tr>
+<tr>
+<td>  as</td>
+<td><code>string|string[]</code></td>
+<td></td>
+<td>URLs</td>
+</tr>
+<tr>
+<td>  rels</td>
+<td><code>string|string[]</code></td>
+<td></td>
+<td>Relationship IDs</td>
+</tr>
+<tr>
+<td>  bs</td>
+<td><code>string|string[]</code></td>
+<td></td>
+<td>URLs</td>
+</tr>
+<tr>
+<td>  visibility</td>
+<td><code>string</code></td>
+<td><code>'all'</code></td>
+<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
+</tr>
+<tr>
+<td> sortBy</td>
+<td><code>string</code></td>
+<td><code>'createdAt'</code></td>
+<td>One of: <code>'createdAt'</code></td>
+</tr>
+<tr>
+<td> offset</td>
+<td><code>number</code></td>
+<td>0</td>
+<td></td>
+</tr>
+<tr>
+<td> limit</td>
+<td><code>number</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td> reverse</td>
+<td><code>boolean</code></td>
+<td><code>false</code></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;Relationship[]&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>get(url)</h3>
+<p>Get an individual relationship by its URL.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>url</td>
+<td><code>string</code></td>
+<td></td>
+<td>Relationship URL (required)</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;Relationship&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>add(relationship)</h3>
+<p>Add a relationship to the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>relationship</td>
+<td><code>Object</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td> a</td>
+<td><code>string</code></td>
+<td></td>
+<td>The URL of the “object” of the relationship (required)</td>
+</tr>
+<tr>
+<td> rel</td>
+<td><code>string</code></td>
+<td></td>
+<td>The ID of the relationship (required)</td>
+</tr>
+<tr>
+<td> b</td>
+<td><code>string</code></td>
+<td></td>
+<td>The URL of the “subject” of the relationship (required)</td>
+</tr>
+<tr>
+<td> visibility</td>
+<td><code>string</code></td>
+<td><code>'public'</code></td>
+<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;Relationship&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>edit(url, relationship)</h3>
+<p>Edit a relationship on the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>url</td>
+<td><code>string</code></td>
+<td></td>
+<td>The URL of the relationship you want to edit (required)</td>
+</tr>
+<tr>
+<td>relationship</td>
+<td><code>Object</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td> a</td>
+<td><code>string</code></td>
+<td></td>
+<td>The URL of the “object” of the relationship</td>
+</tr>
+<tr>
+<td> rel</td>
+<td><code>string</code></td>
+<td></td>
+<td>The ID of the relationship</td>
+</tr>
+<tr>
+<td> b</td>
+<td><code>string</code></td>
+<td></td>
+<td>The URL of the “subject” of the relationship</td>
+</tr>
+<tr>
+<td> visibility</td>
+<td><code>string</code></td>
+<td><code>'public'</code></td>
+<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;Relationship&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>delete(url)</h3>
+<p>Delete a relationship on the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>url</td>
+<td><code>string</code></td>
+<td></td>
+<td>The URL of the relationship you want to delete (required)</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;void&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+</main>
+    </div>
+  </body>
+  <script type="module" src="/assets/admin.js"></script>
+  <script>
+    document.querySelector('.nav-open').addEventListener('click', e => {
+      document.querySelector('nav').classList.add('show')
+    })
+    document.querySelector('.nav-close').addEventListener('click', e => {
+      document.querySelector('nav').classList.remove('show')
+    })
+  </script>
+</html>

--- a/docs/api/search.html
+++ b/docs/api/search.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/browser-integration.html
+++ b/docs/browser-integration.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/common-fields.html
+++ b/docs/common-fields.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/dat-primer.html
+++ b/docs/dat-primer.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/examples/one.html
+++ b/docs/examples/one.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/how-does-it-work.html
+++ b/docs/how-does-it-work.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/mounts.html
+++ b/docs/mounts.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/why-not-rdf.html
+++ b/docs/why-not-rdf.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/follows.html
+++ b/follows.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -70,6 +71,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/person.html
+++ b/person.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/post.html
+++ b/post.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/reaction.html
+++ b/reaction.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/relationship.html
+++ b/relationship.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Relationship (unwalled.garden/relationship) | Unwalled.Garden</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="/assets/styles.css">
+    <link rel="stylesheet" href="/assets/syntax.css">
+  </head>
+  <body>
+    <h1><a href="/">Unwalled.Garden</a></h1>
+    <a class="nav-open"><img src="/assets/hamburger.svg"></a>
+    <div class="notice">Status: DRAFT. Part of the upcoming <a href="https://beakerbrowser.com">Beaker Browser</a> 0.9 release.</div>
+    <div class="page">
+      <nav>
+        <a class="nav-close"><img src="/assets/hamburger.svg"></a>
+        <ul>
+    <li>Docs
+      <ul>
+        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/dat-primer">Dat protocol</a><ul>
+          <li><a href="/docs/mounts">Mounts</a></li>
+        </ul></li>
+        <li><a href="/docs/browser-integration">Browser integration</a></li>
+        <li><a href="/docs/common-fields">Common fields</a></li>
+        <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
+      </ul>
+    </li>
+  </ul>
+<ul>
+  <li>APIs
+    <ul>
+      <li><a href="/docs/api/bookmarks">Bookmarks</a></li>
+      <li><a href="/docs/api/comments">Comments</a></li>
+      <li><a href="/docs/api/follows">Follows</a></li>
+      <li><a href="/docs/api/posts">Posts</a></li>
+      <li><a href="/docs/api/profiles">Profiles</a></li>
+      <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/relationships">Relationships</a></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Schemas
+    <ul>
+      <li><a href="/bookmark">Bookmark</a></li>
+      <li><a href="/comment">Comment</a></li>
+      <li><a href="/follows">Follows</a></li>
+      <li><a href="/person">Person</a></li>
+      <li><a href="/post">Post</a></li>
+      <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/relationship">Relationship</a></li>
+      <li>dir<ul>
+        <li><a href="/dir/data">Data</a></li>
+        <li><a href="/dir/refs">Refs</a></li>
+      </ul></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Links
+    <ul>
+      <li><a href="https://github.com/beakerbrowser/unwalled.garden">Github Repo</a></li>
+      <li><a href="https://beakerbrowser.com">Beaker Browser</a></li>
+      <li><a href="https://dat.foundation">Dat protocol</a></li>
+    </ul>
+  </li>
+</ul>
+      </nav>
+      <main><h2>Relationship <code>unwalled.garden/relationship</code></h2>
+<hr>
+<ul>
+<li>File type</li>
+<li><strong>Description</strong>: A declared relationship between two resources.</li>
+<li><strong>Path</strong>: <code>/.data/unwalled.garden/relationships/*.json</code></li>
+</ul>
+<hr>
+<h4>Notes</h4>
+<p>The way to read relationships is as follows:</p>
+<pre><code>{a} is a/an/the {rel} of/to/about/with {b}
+</code></pre>
+<p>For instance, the following record:</p>
+<pre><code class="language-json">{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/relationship"</span>,
+  <span class="hljs-attr">"a"</span>: <span class="hljs-string">"dat://alice.com"</span>,
+  <span class="hljs-attr">"rel"</span>: <span class="hljs-string">"spouse"</span>,
+  <span class="hljs-attr">"b"</span>: <span class="hljs-string">"dat://bob.com"</span>,
+  <span class="hljs-attr">"createdAt"</span>: <span class="hljs-string">"2018-12-07T02:52:11.947Z"</span>
+}
+</code></pre>
+<p>Should be read as:</p>
+<pre><code>dat://alice.com is the spouse of dat://bob.com
+</code></pre>
+<p>The <code>rel</code> field may be any alphanumeric string. Here are some suggested values:</p>
+<ul>
+<li>Friends
+<ul>
+<li><code>&quot;acquaintance&quot;</code></li>
+<li><code>&quot;friend&quot;</code></li>
+<li><code>&quot;significantOther&quot;</code></li>
+<li><code>&quot;neighbor&quot;</code></li>
+</ul>
+</li>
+<li>Enemies
+<ul>
+<li><code>&quot;antagonist&quot;</code></li>
+<li><code>&quot;critic&quot;</code></li>
+<li><code>&quot;enemy&quot;</code></li>
+<li><code>&quot;hater&quot;</code></li>
+<li><code>&quot;rival&quot;</code></li>
+<li><code>&quot;suspicious&quot;</code></li>
+</ul>
+</li>
+<li>Events
+<ul>
+<li><code>&quot;attendee&quot;</code></li>
+<li><code>&quot;participant&quot;</code></li>
+</ul>
+</li>
+<li>Family
+<ul>
+<li><code>&quot;ancestor&quot;</code></li>
+<li><code>&quot;child&quot;</code></li>
+<li><code>&quot;descendant&quot;</code></li>
+<li><code>&quot;engaged&quot;</code></li>
+<li><code>&quot;grandchild&quot;</code></li>
+<li><code>&quot;grandparent&quot;</code></li>
+<li><code>&quot;lifePartner&quot;</code></li>
+<li><code>&quot;parent&quot;</code></li>
+<li><code>&quot;sibling&quot;</code></li>
+<li><code>&quot;spouse&quot;</code></li>
+</ul>
+</li>
+<li>Projects
+<ul>
+<li><code>&quot;alternative&quot;</code></li>
+<li><code>&quot;author&quot;</code></li>
+<li><code>&quot;competitor&quot;</code></li>
+<li><code>&quot;contributor&quot;</code></li>
+<li><code>&quot;creator&quot;</code></li>
+<li><code>&quot;designer&quot;</code></li>
+<li><code>&quot;evangelist&quot;</code></li>
+<li><code>&quot;fan&quot;</code></li>
+<li><code>&quot;founder&quot;</code></li>
+<li><code>&quot;implementor&quot;</code></li>
+<li><code>&quot;inspiration&quot;</code></li>
+<li><code>&quot;passionate&quot;</code></li>
+<li><code>&quot;promoter&quot;</code></li>
+<li><code>&quot;supporter&quot;</code></li>
+<li><code>&quot;user&quot;</code></li>
+</ul>
+</li>
+<li>Work
+<ul>
+<li><code>&quot;advisor&quot;</code></li>
+<li><code>&quot;apprentice&quot;</code></li>
+<li><code>&quot;collaborator&quot;</code></li>
+<li><code>&quot;colleague&quot;</code></li>
+<li><code>&quot;employer&quot;</code></li>
+<li><code>&quot;funder&quot;</code></li>
+<li><code>&quot;mentor&quot;</code></li>
+</ul>
+</li>
+</ul>
+<h4>Examples</h4>
+<pre><code class="language-json">{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/relationship"</span>,
+  <span class="hljs-attr">"a"</span>: <span class="hljs-string">"dat://alice.com"</span>,
+  <span class="hljs-attr">"rel"</span>: <span class="hljs-string">"spouse"</span>,
+  <span class="hljs-attr">"b"</span>: <span class="hljs-string">"dat://bob.com"</span>,
+  <span class="hljs-attr">"createdAt"</span>: <span class="hljs-string">"2018-12-07T02:52:11.947Z"</span>
+}
+</code></pre>
+<h4>Schema</h4>
+<pre><code class="language-json">{
+  <span class="hljs-attr">"$schema"</span>: <span class="hljs-string">"http://json-schema.org/draft-07/schema#"</span>,
+  <span class="hljs-attr">"$id"</span>: <span class="hljs-string">"dat://unwalled.garden/relationship.json"</span>,
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Relationship"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A declared relationship between two resources."</span>,
+  <span class="hljs-attr">"required"</span>: [
+    <span class="hljs-string">"type"</span>,
+    <span class="hljs-string">"a"</span>,
+    <span class="hljs-string">"rel"</span>,
+    <span class="hljs-string">"b"</span>,
+    <span class="hljs-string">"createdAt"</span>
+  ],
+  <span class="hljs-attr">"properties"</span>: {
+    <span class="hljs-attr">"type"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"const"</span>: <span class="hljs-string">"unwalled.garden/relationship"</span>
+    },
+    <span class="hljs-attr">"a"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>
+    },
+    <span class="hljs-attr">"rel"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"pattern"</span>: <span class="hljs-string">"^[A-Za-z0-9]*$"</span>
+    },
+    <span class="hljs-attr">"b"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>
+    },
+    <span class="hljs-attr">"createdAt"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>
+    },
+    <span class="hljs-attr">"updatedAt"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>
+    }
+  }
+}
+</code></pre>
+</main>
+    </div>
+  </body>
+  <script type="module" src="/assets/admin.js"></script>
+  <script>
+    document.querySelector('.nav-open').addEventListener('click', e => {
+      document.querySelector('nav').classList.add('show')
+    })
+    document.querySelector('.nav-close').addEventListener('click', e => {
+      document.querySelector('nav').classList.remove('show')
+    })
+  </script>
+</html>


### PR DESCRIPTION
Adds "relationships". Example relationship:

```json
{
  "type": "unwalled.garden/relationship",
  "a": "dat://alice.com",
  "rel": "spouse",
  "b": "dat://bob.com",
  "createdAt": "2018-12-07T02:52:11.947Z"
}
```

Relationships are declarations of a linkage between two resources on the Web. They can be used to declare things such as "Alice is the spouse of Bob" and "Carla is an employee of Foo Inc."

The records take the shape of `{a, rel, b}`. The way to read relationships is as follows:

```
{a} is a/an/the {rel} of/to/about/with {b}
```

For instance, the example above reads as:

```
dat://alice.com is the spouse of dat://bob.com
```

I don't have a very specific use-case in mind for relationships, other than fulfilling a natural part of social networking (declaring your relationships with each other and things in the world).