### PR TITLE
Add tools for extending schemas

### DIFF
--- a/_md/bookmark.md
+++ b/_md/bookmark.md
@@ -58,6 +58,9 @@
         "pattern": "^[A-Za-z][A-Za-z0-9-_?]*$"
       }
     },
+    "ext" {
+      "type": "object"
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time"

--- a/_md/comment.md
+++ b/_md/comment.md
@@ -64,6 +64,9 @@
       "type": "string",
       "description": "The post's text content"
     },
+    "ext" {
+      "type": "object"
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time",

--- a/_md/docs/api/bookmarks.md
+++ b/_md/docs/api/bookmarks.md
@@ -18,8 +18,8 @@ await bookmarks.list({
 await bookmarks.get(author, href)
 
 // write
-await bookmarks.add({href, title, description, tags, visibility})
-await bookmarks.edit(href, {href, title, description, tags, visibility})
+await bookmarks.add({href, title, description, tags, ext, visibility})
+await bookmarks.edit(href, {href, title, description, tags, ext, visibility})
 await bookmarks.remove(href)
 ```
 
@@ -41,6 +41,7 @@ The values returned by bookmark functions will fit the following object shape:
 |&emsp;title|`string`||
 |&emsp;description|`string`||
 |&emsp;type|`string[]`||
+|ext|`Object`|The [extension](/docs/how-to-extend-schemas) object|
 |visibility|`string`|The [visibility](/docs/common-fields#visibility) of the bookmark|
 
 ---
@@ -93,6 +94,7 @@ Add a bookmark to the current user's site.
 |&emsp;title|`string`||The bookmark title (required)|
 |&emsp;description|`string`||The bookmark description|
 |&emsp;tags|`string[]`||The bookmark tags|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
 |&emsp;visibility|`string`|`'private'`|See [visibility](/docs/common-fields#visibility)|
 
 |Returns|
@@ -113,6 +115,7 @@ Edit a bookmark on the current user's site.
 |&emsp;title|`string`||The bookmark title (required)|
 |&emsp;description|`string`||The bookmark description|
 |&emsp;tags|`string[]`||The bookmark tags|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
 |&emsp;visibility|`string`|`'private'`|See [visibility](/docs/common-fields#visibility)|
 
 |Returns|

--- a/_md/docs/api/comments.md
+++ b/_md/docs/api/comments.md
@@ -24,8 +24,8 @@ await comments.thread(topic, {
 await comments.get(url)
 
 // write
-await comments.add(topic, {body, replyTo, visibility})
-await comments.edit(url, {body, replyTo, visibility})
+await comments.add(topic, {body, replyTo, ext, visibility})
+await comments.edit(url, {body, replyTo, ext, visibility})
 await comments.delete(url)
 ```
 
@@ -48,6 +48,7 @@ The values returned by most comment functions will fit the following object shap
 |&emsp;title|`string`||
 |&emsp;description|`string`||
 |&emsp;type|`string[]`||
+|ext|`Object`|The [extension](/docs/how-to-extend-schemas) object|
 |visibility|`string`|The [visibility](/docs/common-fields#visibility) of the comment|
 
 ---
@@ -71,6 +72,7 @@ The values returned by the `thread()` function will fit the following object sha
 |&emsp;title|`string`||
 |&emsp;description|`string`||
 |&emsp;type|`string[]`||
+|ext|`Object`|The [extension](/docs/how-to-extend-schemas) object|
 |visibility|`string`|The [visibility](/docs/common-fields#visibility) of the comment|
 
 ---
@@ -146,6 +148,7 @@ Add a comment to the current user's site.
 |comment|`string|Object`||If a string, specifies the body (required)|
 |&emsp;body|`string`||The comment body (required)|
 |&emsp;replyTo|`string`||The URL of the comment being replied to|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
 |&emsp;visibility|`string`|`'public'`|See [visibility](/docs/common-fields#visibility)|
 
 |Returns|
@@ -171,6 +174,7 @@ Edit a comment on the current user's site.
 |comment|`string|Object`||If a string, specifies the body (required)|
 |&emsp;body|`string`||The comment body (required)|
 |&emsp;replyTo|`string`||The URL of the comment being replied to|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
 |&emsp;visibility|`string`|`'public'`|See [visibility](/docs/common-fields#visibility)|
 
 |Returns|

--- a/_md/docs/api/posts.md
+++ b/_md/docs/api/posts.md
@@ -18,8 +18,8 @@ await posts.list({
 await posts.get(url)
 
 // write
-await posts.add({body, visibility})
-await posts.edit(url, {body, visibility})
+await posts.add({body, ext, visibility})
+await posts.edit(url, {body, ext, visibility})
 await posts.delete(url)
 ```
 
@@ -40,6 +40,7 @@ The values returned by post functions will fit the following object shape:
 |&emsp;title|`string`||
 |&emsp;description|`string`||
 |&emsp;type|`string[]`||
+|ext|`Object`|The [extension](/docs/how-to-extend-schemas) object|
 |visibility|`string`|The [visibility](/docs/common-fields#visibility) of the post|
 
 ---
@@ -87,6 +88,7 @@ Add a post to the current user's site.
 |-|-|-|-|
 |post|`string|Object`||If a string, specifies the body (required)|
 |&emsp;body|`string`||The post body (required)|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
 |&emsp;visibility|`string`|`'public'`|See [visibility](/docs/common-fields#visibility)|
 
 |Returns|
@@ -111,6 +113,7 @@ Edit a post on the current user's site.
 |url|`string`||The URL of the post you want to edit (required)|
 |post|`string|Object`||If a string, specifies the body (required)|
 |&emsp;body|`string`||The post body (required)|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
 |&emsp;visibility|`string`|`'public'`|See [visibility](/docs/common-fields#visibility)|
 
 |Returns|

--- a/_md/docs/how-to-extend-schemas.md
+++ b/_md/docs/how-to-extend-schemas.md
@@ -1,0 +1,63 @@
+## How to extend the schemas
+
+Sometimes the core schemas just ain't enough. Maybe you want to make a forum app that embeds polls in the discussions? Or maybe you want to add tags to your comments? There are lots of reasons that you might want to extend the schema.
+
+To handle this, we decided to create a standard process for "extensions."
+
+### The ext object
+
+Every schema has an optional `ext` object to contain all extensions. Here's an example which adds tags to a [Comment](/comment):
+
+```json
+{
+  "type": "unwalled.garden/comment",
+  "topic": "dat://beakerbrowser.com/docs",
+  "body": "These docs need some work!",
+  "createdAt": "2018-12-07T02:52:11.947Z",
+  "ext": {
+    "my-personal-schemas.com/tags": {
+      "tags": ["feedback", "criticism"]
+    }
+  }
+}
+```
+
+The `ext` object should fit the following form:
+
+```js
+ext: {
+  [schemaUrl]: Object
+}
+```
+
+The `schemaUrl` key behaves like the `type` field in the standard schemas. It indicates where documentation for the extension object can be found. The extension `Object` is entirely up to you, but it should be an object (not just a string or number).
+
+### A word of warning
+
+Your extensions will not be universally supported, so you should think carefully about how other applications will interact with them.
+
+Here's an example of how an extension could fail to work as expected:
+
+ - You add a "subfeed" extension to the [Post](/post) schema. Your idea is, if the post has a subfeed, it goes into the subfeed instead of showing on the main feed.
+ - You build your app to respect the subfeed extension and everything seems well...
+ - ...But then you try another app and see that the subfeed posts are still in the main feed!
+
+What happened here? Well, apps will ignore extensions that they don't understand. This can create surprising interactions if you're not careful.
+
+If your extension has to be understood by other apps to work correctly, then the extension won't work.
+
+### FAQ
+
+#### Do I have to use a schema URL?
+
+Yes! If you don't use a URL to identify your extension's schema, then it's possible that your extension will conflict with other peoples' extensions. For instance, what if everybody used `"tags"` to identify their tags extension, but half of them differed? You'd run into tons of conflicting data.
+
+#### Do I have to publish the schema documentation?
+
+It's a good idea but it's not required. So long as you control the URL, you can use it.
+
+#### Why use the ext field? Why not just make any change I want?
+
+The entire purpose of schemas is to ensure compatibility between applications. If developers make arbitrary changes, their changes could start to conflict in subtle ways. By using the `ext` object, we ensure that extensions will never collide.
+
+

--- a/_md/docs/why-not-rdf.md
+++ b/_md/docs/why-not-rdf.md
@@ -72,7 +72,7 @@ paul.title = 'Paul Frazee'
 paul.description = 'Beaker guy'
 ```
 
-If schemas *must* be combined, only then might we use URL keys:
+If schemas *must* be combined, only then might we use URL keys (see [How to extend the schemas](/docs/how-to-extend-schemas)):
 
 
 ```json
@@ -80,10 +80,11 @@ If schemas *must* be combined, only then might we use URL keys:
   "type": "websites.com/manifest",
   "title": "Paul Frazee",
   "description": "Beaker guy",
-  "social.com/follows": [
-    "dat://alice.com",
-    "dat://bob.com"
-  ]
+  "ext": {
+    "social.com/follows": {
+      "urls": ["dat://alice.com", "dat://bob.com"]
+    }
+  }
 }
 ```
 

--- a/_md/post.md
+++ b/_md/post.md
@@ -39,6 +39,9 @@
       "description": "The post's text body",
       "maxLength": 1000000
     },
+    "ext" {
+      "type": "object"
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time",

--- a/application.html
+++ b/application.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/assets/nav.html
+++ b/assets/nav.html
@@ -1,12 +1,14 @@
 <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/bookmark.html
+++ b/bookmark.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>
@@ -84,46 +86,49 @@
 </code></pre>
 <h4>Schema</h4>
 <pre><code class="language-json">{
-  <span class="hljs-attr">"$schema"</span>: <span class="hljs-string">"http://json-schema.org/draft-07/schema#"</span>,
-  <span class="hljs-attr">"$id"</span>: <span class="hljs-string">"dat://unwalled.garden/bookmark.json"</span>,
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Bookmark"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A saved/shared link to some URL."</span>,
-  <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"type"</span>, <span class="hljs-string">"href"</span>, <span class="hljs-string">"title"</span>, <span class="hljs-string">"createdAt"</span>],
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"type"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The object's type"</span>,
-      <span class="hljs-attr">"const"</span>: <span class="hljs-string">"unwalled.garden/bookmark"</span>
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/bookmark.json",
+  "type": "object",
+  "title": "Bookmark",
+  "description": "A saved/shared link to some URL.",
+  "required": ["type", "href", "title", "createdAt"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The object's type",
+      "const": "unwalled.garden/bookmark"
     },
-    <span class="hljs-attr">"href"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>,
-      <span class="hljs-attr">"maxLength"</span>: <span class="hljs-number">10000</span>
+    "href": {
+      "type": "string",
+      "format": "uri",
+      "maxLength": 10000
     },
-    <span class="hljs-attr">"title"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"maxLength"</span>: <span class="hljs-number">280</span>
+    "title": {
+      "type": "string",
+      "maxLength": 280
     },
-    <span class="hljs-attr">"description"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"maxLength"</span>: <span class="hljs-number">560</span>
+    "description": {
+      "type": "string",
+      "maxLength": 560
     },
-    <span class="hljs-attr">"tags"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
-      <span class="hljs-attr">"items"</span>: {
-        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-        <span class="hljs-attr">"maxLength"</span>: <span class="hljs-number">100</span>,
-        <span class="hljs-attr">"pattern"</span>: <span class="hljs-string">"^[A-Za-z][A-Za-z0-9-_?]*$"</span>
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "maxLength": 100,
+        "pattern": "^[A-Za-z][A-Za-z0-9-_?]*$"
       }
     },
-    <span class="hljs-attr">"createdAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>
+    "ext" {
+      "type": "object"
     },
-    <span class="hljs-attr">"updatedAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
     }
   }
 }

--- a/bookmark.json
+++ b/bookmark.json
@@ -32,6 +32,9 @@
         "pattern": "^[A-Za-z][A-Za-z0-9-_?]*$"
       }
     },
+    "ext" {
+      "type": "object"
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time"

--- a/comment.html
+++ b/comment.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>
@@ -90,46 +92,49 @@
 </code></pre>
 <h4>Schema</h4>
 <pre><code class="language-json">{
-  <span class="hljs-attr">"$schema"</span>: <span class="hljs-string">"http://json-schema.org/draft-07/schema#"</span>,
-  <span class="hljs-attr">"$id"</span>: <span class="hljs-string">"dat://unwalled.garden/comment.json"</span>,
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Comment"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A text post about some resource."</span>,
-  <span class="hljs-attr">"required"</span>: [
-    <span class="hljs-string">"type"</span>,
-    <span class="hljs-string">"topic"</span>,
-    <span class="hljs-string">"body"</span>,
-    <span class="hljs-string">"createdAt"</span>
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/comment.json",
+  "type": "object",
+  "title": "Comment",
+  "description": "A text post about some resource.",
+  "required": [
+    "type",
+    "topic",
+    "body",
+    "createdAt"
   ],
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"type"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The object's type"</span>,
-      <span class="hljs-attr">"const"</span>: <span class="hljs-string">"unwalled.garden/comment"</span>
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The object's type",
+      "const": "unwalled.garden/comment"
     },
-    <span class="hljs-attr">"topic"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"What this comment is about"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>
+    "topic": {
+      "type": "string",
+      "description": "What this comment is about",
+      "format": "uri"
     },
-    <span class="hljs-attr">"replyTo"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"What this comment is replying to"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>
+    "replyTo": {
+      "type": "string",
+      "description": "What this comment is replying to",
+      "format": "uri"
     },
-    <span class="hljs-attr">"body"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The post's text content"</span>
+    "body": {
+      "type": "string",
+      "description": "The post's text content"
     },
-    <span class="hljs-attr">"createdAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The time of this post's creation"</span>
+    "ext" {
+      "type": "object"
     },
-    <span class="hljs-attr">"updatedAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The time of this post's last edit"</span>
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The time of this post's creation"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The time of this post's last edit"
     }
   }
 }

--- a/comment.json
+++ b/comment.json
@@ -30,6 +30,9 @@
       "type": "string",
       "description": "The post's text content"
     },
+    "ext" {
+      "type": "object"
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time",

--- a/dir/data.html
+++ b/dir/data.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/dir/refs.html
+++ b/dir/refs.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/api/bookmarks.html
+++ b/docs/api/bookmarks.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>
@@ -80,8 +82,8 @@
 <span class="hljs-keyword">await</span> bookmarks.get(author, href)
 
 <span class="hljs-comment">// write</span>
-<span class="hljs-keyword">await</span> bookmarks.add({href, title, description, tags, visibility})
-<span class="hljs-keyword">await</span> bookmarks.edit(href, {href, title, description, tags, visibility})
+<span class="hljs-keyword">await</span> bookmarks.add({href, title, description, tags, ext, visibility})
+<span class="hljs-keyword">await</span> bookmarks.edit(href, {href, title, description, tags, ext, visibility})
 <span class="hljs-keyword">await</span> bookmarks.remove(href)
 </code></pre>
 <hr>
@@ -145,6 +147,11 @@
 <td> type</td>
 <td><code>string[]</code></td>
 <td></td>
+</tr>
+<tr>
+<td>ext</td>
+<td><code>Object</code></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
 <td>visibility</td>
@@ -317,6 +324,12 @@
 <td>The bookmark tags</td>
 </tr>
 <tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
+</tr>
+<tr>
 <td> visibility</td>
 <td><code>string</code></td>
 <td><code>'private'</code></td>
@@ -384,6 +397,12 @@
 <td><code>string[]</code></td>
 <td></td>
 <td>The bookmark tags</td>
+</tr>
+<tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
 <td> visibility</td>

--- a/docs/api/comments.html
+++ b/docs/api/comments.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>
@@ -86,8 +88,8 @@
 <span class="hljs-keyword">await</span> comments.get(url)
 
 <span class="hljs-comment">// write</span>
-<span class="hljs-keyword">await</span> comments.add(topic, {body, replyTo, visibility})
-<span class="hljs-keyword">await</span> comments.edit(url, {body, replyTo, visibility})
+<span class="hljs-keyword">await</span> comments.add(topic, {body, replyTo, ext, visibility})
+<span class="hljs-keyword">await</span> comments.edit(url, {body, replyTo, ext, visibility})
 <span class="hljs-keyword">await</span> comments.delete(url)
 </code></pre>
 <hr>
@@ -156,6 +158,11 @@
 <td> type</td>
 <td><code>string[]</code></td>
 <td></td>
+</tr>
+<tr>
+<td>ext</td>
+<td><code>Object</code></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
 <td>visibility</td>
@@ -240,6 +247,11 @@
 <td> type</td>
 <td><code>string[]</code></td>
 <td></td>
+</tr>
+<tr>
+<td>ext</td>
+<td><code>Object</code></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
 <td>visibility</td>
@@ -477,6 +489,12 @@
 <td>The URL of the comment being replied to</td>
 </tr>
 <tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
+</tr>
+<tr>
 <td> visibility</td>
 <td><code>string</code></td>
 <td><code>'public'</code></td>
@@ -536,6 +554,12 @@
 <td><code>string</code></td>
 <td></td>
 <td>The URL of the comment being replied to</td>
+</tr>
+<tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
 <td> visibility</td>

--- a/docs/api/follows.html
+++ b/docs/api/follows.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/api/posts.html
+++ b/docs/api/posts.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>
@@ -80,8 +82,8 @@
 <span class="hljs-keyword">await</span> posts.get(url)
 
 <span class="hljs-comment">// write</span>
-<span class="hljs-keyword">await</span> posts.add({body, visibility})
-<span class="hljs-keyword">await</span> posts.edit(url, {body, visibility})
+<span class="hljs-keyword">await</span> posts.add({body, ext, visibility})
+<span class="hljs-keyword">await</span> posts.edit(url, {body, ext, visibility})
 <span class="hljs-keyword">await</span> posts.delete(url)
 </code></pre>
 <hr>
@@ -140,6 +142,11 @@
 <td> type</td>
 <td><code>string[]</code></td>
 <td></td>
+</tr>
+<tr>
+<td>ext</td>
+<td><code>Object</code></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
 <td>visibility</td>
@@ -282,6 +289,12 @@
 <td>The post body (required)</td>
 </tr>
 <tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
+</tr>
+<tr>
 <td> visibility</td>
 <td><code>string</code></td>
 <td><code>'public'</code></td>
@@ -335,6 +348,12 @@
 <td><code>string</code></td>
 <td></td>
 <td>The post body (required)</td>
+</tr>
+<tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
 <td> visibility</td>

--- a/docs/api/profiles.html
+++ b/docs/api/profiles.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/api/reactions.html
+++ b/docs/api/reactions.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/api/search.html
+++ b/docs/api/search.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/browser-integration.html
+++ b/docs/browser-integration.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/common-fields.html
+++ b/docs/common-fields.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/dat-primer.html
+++ b/docs/dat-primer.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/examples/one.html
+++ b/docs/examples/one.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/how-does-it-work.html
+++ b/docs/how-does-it-work.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/how-to-extend-schemas.html
+++ b/docs/how-to-extend-schemas.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html>
+  <head>
+    <title>How to extend the schemas | Unwalled.Garden</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="/assets/styles.css">
+    <link rel="stylesheet" href="/assets/syntax.css">
+  </head>
+  <body>
+    <h1><a href="/">Unwalled.Garden</a></h1>
+    <a class="nav-open"><img src="/assets/hamburger.svg"></a>
+    <div class="notice">Status: DRAFT. Part of the upcoming <a href="https://beakerbrowser.com">Beaker Browser</a> 0.9 release.</div>
+    <div class="page">
+      <nav>
+        <a class="nav-close"><img src="/assets/hamburger.svg"></a>
+        <ul>
+    <li>Docs
+      <ul>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
+        <li><a href="/docs/dat-primer">Dat protocol</a><ul>
+          <li><a href="/docs/mounts">Mounts</a></li>
+        </ul></li>
+        <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
+      </ul>
+    </li>
+  </ul>
+<ul>
+  <li>APIs
+    <ul>
+      <li><a href="/docs/api/bookmarks">Bookmarks</a></li>
+      <li><a href="/docs/api/comments">Comments</a></li>
+      <li><a href="/docs/api/follows">Follows</a></li>
+      <li><a href="/docs/api/posts">Posts</a></li>
+      <li><a href="/docs/api/profiles">Profiles</a></li>
+      <li><a href="/docs/api/reactions">Reactions</a></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Schemas
+    <ul>
+      <li><a href="/bookmark">Bookmark</a></li>
+      <li><a href="/comment">Comment</a></li>
+      <li><a href="/follows">Follows</a></li>
+      <li><a href="/person">Person</a></li>
+      <li><a href="/post">Post</a></li>
+      <li><a href="/reaction">Reaction</a></li>
+      <li>dir<ul>
+        <li><a href="/dir/data">Data</a></li>
+        <li><a href="/dir/refs">Refs</a></li>
+      </ul></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Links
+    <ul>
+      <li><a href="https://github.com/beakerbrowser/unwalled.garden">Github Repo</a></li>
+      <li><a href="https://beakerbrowser.com">Beaker Browser</a></li>
+      <li><a href="https://dat.foundation">Dat protocol</a></li>
+    </ul>
+  </li>
+</ul>
+      </nav>
+      <main><h2>How to extend the schemas</h2>
+<p>Sometimes the core schemas just ain’t enough. Maybe you want to make a forum app that embeds polls in the discussions? Or maybe you want to add tags to your comments? There are lots of reasons that you might want to extend the schema.</p>
+<p>To handle this, we decided to create a standard process for “extensions.”</p>
+<h3>The ext object</h3>
+<p>Every schema has an optional <code>ext</code> object to contain all extensions. Here’s an example which adds tags to a <a href="/comment">Comment</a>:</p>
+<pre><code class="language-json">{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/comment"</span>,
+  <span class="hljs-attr">"topic"</span>: <span class="hljs-string">"dat://beakerbrowser.com/docs"</span>,
+  <span class="hljs-attr">"body"</span>: <span class="hljs-string">"These docs need some work!"</span>,
+  <span class="hljs-attr">"createdAt"</span>: <span class="hljs-string">"2018-12-07T02:52:11.947Z"</span>,
+  <span class="hljs-attr">"ext"</span>: {
+    <span class="hljs-attr">"my-personal-schemas.com/tags"</span>: {
+      <span class="hljs-attr">"tags"</span>: [<span class="hljs-string">"feedback"</span>, <span class="hljs-string">"criticism"</span>]
+    }
+  }
+}
+</code></pre>
+<p>The <code>ext</code> object should fit the following form:</p>
+<pre><code class="language-js">ext: {
+  [schemaUrl]: <span class="hljs-built_in">Object</span>
+}
+</code></pre>
+<p>The <code>schemaUrl</code> key behaves like the <code>type</code> field in the standard schemas. It indicates where documentation for the extension object can be found. The extension <code>Object</code> is entirely up to you, but it should be an object (not just a string or number).</p>
+<h3>A word of warning</h3>
+<p>Your extensions will not be universally supported, so you should think carefully about how other applications will interact with them.</p>
+<p>Here’s an example of how an extension could fail to work as expected:</p>
+<ul>
+<li>You add a “subfeed” extension to the <a href="/post">Post</a> schema. Your idea is, if the post has a subfeed, it goes into the subfeed instead of showing on the main feed.</li>
+<li>You build your app to respect the subfeed extension and everything seems well…</li>
+<li>…But then you try another app and see that the subfeed posts are still in the main feed!</li>
+</ul>
+<p>What happened here? Well, apps will ignore extensions that they don’t understand. This can create surprising interactions if you’re not careful.</p>
+<p>If your extension has to be understood by other apps to work correctly, then the extension won’t work.</p>
+<h3>FAQ</h3>
+<h4>Do I have to use a schema URL?</h4>
+<p>Yes! If you don’t use a URL to identify your extension’s schema, then it’s possible that your extension will conflict with other peoples’ extensions. For instance, what if everybody used <code>&quot;tags&quot;</code> to identify their tags extension, but half of them differed? You’d run into tons of conflicting data.</p>
+<h4>Do I have to publish the schema documentation?</h4>
+<p>It’s a good idea but it’s not required. So long as you control the URL, you can use it.</p>
+<h4>Why use the ext field? Why not just make any change I want?</h4>
+<p>The entire purpose of schemas is to ensure compatibility between applications. If developers make arbitrary changes, their changes could start to conflict in subtle ways. By using the <code>ext</code> object, we ensure that extensions will never collide.</p>
+</main>
+    </div>
+  </body>
+  <script type="module" src="/assets/admin.js"></script>
+  <script>
+    document.querySelector('.nav-open').addEventListener('click', e => {
+      document.querySelector('nav').classList.add('show')
+    })
+    document.querySelector('.nav-close').addEventListener('click', e => {
+      document.querySelector('nav').classList.remove('show')
+    })
+  </script>
+</html>

--- a/docs/mounts.html
+++ b/docs/mounts.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/docs/why-not-rdf.html
+++ b/docs/why-not-rdf.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>
@@ -117,15 +119,16 @@ paul[<span class="hljs-string">'dat://websites.com/manifest#title'</span>] = <sp
 <pre><code class="language-js">paul.title = <span class="hljs-string">'Paul Frazee'</span>
 paul.description = <span class="hljs-string">'Beaker guy'</span>
 </code></pre>
-<p>If schemas <em>must</em> be combined, only then might we use URL keys:</p>
+<p>If schemas <em>must</em> be combined, only then might we use URL keys (see <a href="/docs/how-to-extend-schemas">How to extend the schemas</a>):</p>
 <pre><code class="language-json">{
   <span class="hljs-attr">"type"</span>: <span class="hljs-string">"websites.com/manifest"</span>,
   <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Paul Frazee"</span>,
   <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Beaker guy"</span>,
-  <span class="hljs-attr">"social.com/follows"</span>: [
-    <span class="hljs-string">"dat://alice.com"</span>,
-    <span class="hljs-string">"dat://bob.com"</span>
-  ]
+  <span class="hljs-attr">"ext"</span>: {
+    <span class="hljs-attr">"social.com/follows"</span>: {
+      <span class="hljs-attr">"urls"</span>: [<span class="hljs-string">"dat://alice.com"</span>, <span class="hljs-string">"dat://bob.com"</span>]
+    }
+  }
 }
 </code></pre>
 <p>The Unwalled.Garden philosophy about RDF is <a href="https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it">YAGNI (You Ain’t Gonna Need It)</a>. We see RDF’s complexity as a turn-off to developers and something we should try to avoid if we can.</p>

--- a/follows.html
+++ b/follows.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/index.html
+++ b/index.html
@@ -39,12 +39,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/person.html
+++ b/person.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>

--- a/post.html
+++ b/post.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>
@@ -81,32 +83,35 @@
 </code></pre>
 <h4>Schema</h4>
 <pre><code class="language-json">{
-  <span class="hljs-attr">"$schema"</span>: <span class="hljs-string">"http://json-schema.org/draft-07/schema#"</span>,
-  <span class="hljs-attr">"$id"</span>: <span class="hljs-string">"dat://unwalled.garden/post.json"</span>,
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Post"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A broadcasted piece of content."</span>,
-  <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"type"</span>, <span class="hljs-string">"body"</span>, <span class="hljs-string">"createdAt"</span>],
-  <span class="hljs-attr">"properties"</span>: {
-    <span class="hljs-attr">"type"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The object's type"</span>,
-      <span class="hljs-attr">"const"</span>: <span class="hljs-string">"unwalled.garden/post"</span>
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/post.json",
+  "type": "object",
+  "title": "Post",
+  "description": "A broadcasted piece of content.",
+  "required": ["type", "body", "createdAt"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The object's type",
+      "const": "unwalled.garden/post"
     },
-    <span class="hljs-attr">"body"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The post's text body"</span>,
-      <span class="hljs-attr">"maxLength"</span>: <span class="hljs-number">1000000</span>
+    "body": {
+      "type": "string",
+      "description": "The post's text body",
+      "maxLength": 1000000
     },
-    <span class="hljs-attr">"createdAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The time of this post's creation"</span>
+    "ext" {
+      "type": "object"
     },
-    <span class="hljs-attr">"updatedAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>,
-      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The time of this post's last edit"</span>
+    "createdAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The time of this post's creation"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "The time of this post's last edit"
     }
   }
 }

--- a/post.json
+++ b/post.json
@@ -16,6 +16,9 @@
       "description": "The post's text body",
       "maxLength": 1000000
     },
+    "ext" {
+      "type": "object"
+    },
     "createdAt": {
       "type": "string",
       "format": "date-time",

--- a/reaction.html
+++ b/reaction.html
@@ -16,12 +16,14 @@
         <ul>
     <li>Docs
       <ul>
-        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/how-does-it-work">How it works</a><ul>
+          <li><a href="/docs/common-fields">Common fields</a></li>
+          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
+          <li><a href="/docs/browser-integration">Browser integration</a></li>
+        </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
           <li><a href="/docs/mounts">Mounts</a></li>
         </ul></li>
-        <li><a href="/docs/browser-integration">Browser integration</a></li>
-        <li><a href="/docs/common-fields">Common fields</a></li>
         <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
       </ul>
     </li>


### PR DESCRIPTION
This PR adds the `ext` object for some schemas. It's designed to make a standard solution for extending schemas. From the docs:

## How to extend the schemas

Sometimes the core schemas just ain't enough. Maybe you want to make a forum app that embeds polls in the discussions? Or maybe you want to add tags to your comments? There are lots of reasons that you might want to extend the schema.

To handle this, we decided to create a standard process for "extensions."

### The ext object

Every schema has an optional `ext` object to contain all extensions. Here's an example which adds tags to a [Comment](/comment):

```json
{
  "type": "unwalled.garden/comment",
  "topic": "dat://beakerbrowser.com/docs",
  "body": "These docs need some work!",
  "createdAt": "2018-12-07T02:52:11.947Z",
  "ext": {
    "my-personal-schemas.com/tags": {
      "tags": ["feedback", "criticism"]
    }
  }
}
```

The `ext` object should fit the following form:

```js
ext: {
  [schemaUrl]: Object
}
```

The `schemaUrl` key behaves like the `type` field in the standard schemas. It indicates where documentation for the extension object can be found. The extension `Object` is entirely up to you, but it should be an object (not just a string or number).