### PR TITLE
Sitelists

### DIFF
--- a/_md/dir/data.md
+++ b/_md/dir/data.md
@@ -17,3 +17,4 @@
 |`/follows.json`|[Follows](/follows)|
 |`/posts/*.json`|[Post](/post)|
 |`/reactions/*.json`|[Reaction](/reaction)|
+|`/userlists/*.json`|[Userlist](/userlist)|

--- a/_md/docs/api/sitelists.md
+++ b/_md/docs/api/sitelists.md
@@ -1,0 +1,213 @@
+## Sitelists API
+
+Sitelists are collections of sites. They can be used to share recommended follows, recommended apps, employee lists, and more.
+
+In addition to a title and description, sitelists have a `name` which determines the filename of the sitelist. A site cannot publish two sitelists with the same name.
+
+A sitelist should only include links to sites (not to files or pages).
+
+---
+
+```js
+import {sitelists} from 'dat://unwalled.garden/index.js'
+
+// read
+await sitelists.list({
+  filters: {authors, visibility},
+  sortBy,
+  offset,
+  limit,
+  reverse
+})
+await sitelists.get(author, name)
+
+// write
+await sitelists.add({name, title, description, ext, visibility})
+await sitelists.edit(name, {name, title, description, ext, visibility})
+await sitelists.remove(name)
+await sitelists.addSite(name, {url, title, description, type, ext})
+await sitelists.editSite(name, url, {url, title, description, type, ext})
+await sitelists.removeSite(name, url)
+```
+
+---
+
+### SiteList
+
+The values returned by sitelist functions will fit the following object shape:
+
+|Attribute|Type|Usage|
+|-|-|-|
+|url|`string`|The URL of the sitelist|
+|name|`string`|The name of the sitelist|
+|title|`string`|The title of the sitelist|
+|description|`string`|The description of the sitelist|
+|sites|`SiteListItem[]`|The sites in the sitelist|
+|createdAt|`string`|The timestamp of when the sitelist claims it was created|
+|updatedAt|`string`|The timestamp of when the sitelist claims it was last updated|
+|author|`Object`|The site that authored the sitelist|
+|&emsp;url|`string`||
+|&emsp;title|`string`||
+|&emsp;description|`string`||
+|&emsp;type|`string[]`||
+|ext|`Object`|The [extension](/docs/how-to-extend-schemas) object|
+|visibility|`string`|The [visibility](/docs/common-fields#visibility) of the sitelist record|
+
+---
+
+### SiteListItem
+
+The `SiteList` includes an array of sites objects that fit this shape:
+
+|Attribute|Type|Usage|
+|-|-|-|
+|url|`string`|The URL of the site|
+|title|`string`|The title of the site|
+|description|`string`|The description of the site|
+|type|`string[]`|The type of the site|
+|ext|`Object`|The [extension](/docs/how-to-extend-schemas) object|
+
+---
+
+### list(opts)
+
+List sitelists on the network.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|opts|`Object`|||
+|&emsp;filters|`Object`|||
+|&emsp;&emsp;authors|`string|string[]`||Site URLs|
+|&emsp;&emsp;visibility|`string`|`'all'`|See [visibility](/docs/common-fields#visibility)|
+|&emsp;sortBy|`string`|`'topic'`|One of: `'topic'`|
+|&emsp;offset|`number`|0||
+|&emsp;limit|`number`|||
+|&emsp;reverse|`boolean`|`false`||
+
+|Returns|
+|-|
+|`Promise<SiteList[]>`|
+
+---
+
+### get(author, name)
+
+Get a sitelist by author and name.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|author|`string`||Site URL (required)|
+|name|`string`||Sitelist name (required)|
+
+|Returns|
+|-|
+|`Promise<SiteList>`|
+
+---
+
+### add(sitelist)
+
+Add a sitelist to the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|sitelist|`Object`|||
+|&emsp;name|`string`||The sitelist name (required)|
+|&emsp;title|`string`||The sitelist title|
+|&emsp;description|`string`||The sitelist description|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
+|&emsp;[visibility](/docs/common-fields#visibility)|`string`|`'public'`|One of: `'public'`, `'private'`|
+
+|Returns|
+|-|
+|`Promise<SiteList>`|
+
+---
+
+### edit(name, sitelist)
+
+Edit a sitelist on the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|name|`string`||The sitelist name (required)|
+|sitelist|`Object`|||
+|&emsp;name|`string`||The sitelist name|
+|&emsp;title|`string`||The sitelist title|
+|&emsp;description|`string`||The sitelist description|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
+|&emsp;[visibility](/docs/common-fields#visibility)|`string`|`'public'`|One of: `'public'`, `'private'`|
+
+|Returns|
+|-|
+|`Promise<SiteList>`|
+
+---
+
+### remove(name)
+
+Remove a sitelist from the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|name|`string`||The sitelist name (required)|
+
+|Returns|
+|-|
+|`Promise<void>`|
+
+---
+
+### addSite(name, site)
+
+Add a site to a sitelist on the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|name|`string`||The sitelist name (required)|
+|site|`Object`|||
+|&emsp;url|`string`||The site URL (required)|
+|&emsp;title|`string`||The site title|
+|&emsp;description|`string`||The site description|
+|&emsp;type|`string[]`||The site type|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
+
+|Returns|
+|-|
+|`Promise<SiteList>`|
+
+---
+
+### editSite(name, url, site)
+
+Edit a site in a sitelist on the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|name|`string`||The sitelist name (required)|
+|url|`string`||The site URL (required)|
+|site|`Object`|||
+|&emsp;url|`string`||The site URL|
+|&emsp;title|`string`||The site title|
+|&emsp;description|`string`||The site description|
+|&emsp;type|`string[]`||The site type|
+|&emsp;ext|`Object`||The [extension](/docs/how-to-extend-schemas) object|
+
+|Returns|
+|-|
+|`Promise<SiteList>`|
+
+---
+
+### removeSite(name, site)
+
+Remove a site from a sitelist on the current user's site.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|name|`string`||The sitelist name (required)|
+|url|`string`||The site URL (required)|
+
+|Returns|
+|-|
+|`Promise<SiteList>`|

--- a/_md/sitelist.md
+++ b/_md/sitelist.md
@@ -1,0 +1,114 @@
+## Sitelist `unwalled.garden/sitelist`
+
+---
+
+ - File type
+ - **Description**: A list of sites.
+ - **Path**: `/.data/unwalled.garden/sitelists/*.json`
+
+---
+
+#### Notes
+
+The `name` field should be the same as the filename of the JSON file (minus the `.json` extension). A site cannot publish two sitelists with the same name.
+
+The `url` fields of the `sites` should point to the root resource. Paths should be ignored. (It's a site list, not a link list!)
+
+#### Example
+
+```json
+{
+  "type": "unwalled.garden/sitelist",
+  "name": "my-friends",
+  "title": "Friends",
+  "description": "People I know from real life",
+  "sites": [
+    {
+      "url": "dat://43dfc9f23fdded8cc7c01c71c0702a0529130af0258e7fb30bf5a0a3f73d69b3",
+      "title": "Alice",
+      "description": "Advocate of the free and open web",
+      "type": ["unwalled.garden/person"]
+    },
+    {
+      "url": "dat://db10d577c44118c47fb76a69026cba01e90c5919d636b2b6e6ffac3eac52e8fa",
+      "title": "Bob",
+      "description": "Animal lover, career mortician",
+      "type": ["unwalled.garden/person"]
+    }
+  ],
+  "createdAt": "2018-12-07T02:52:11.947Z",
+  "updatedAt": "2018-12-21T06:22:15.401Z"
+}
+```
+
+#### Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/sitelist.json",
+  "type": "object",
+  "title": "Sitelist",
+  "description": "A list of data subscriptions.",
+  "required": [
+    "type",
+    "name",
+    "sites"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "unwalled.garden/sitelist"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9-_?]*$"
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "sites": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["url"],
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string",
+          },
+          "description": {
+            "type": "string",
+          },
+          "type": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ext": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "ext": {
+      "type": "object"
+    }
+  }
+}
+```

--- a/application.html
+++ b/application.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/assets/nav.html
+++ b/assets/nav.html
@@ -20,6 +20,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -32,6 +33,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/bookmark.html
+++ b/bookmark.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/comment.html
+++ b/comment.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/dir/data.html
+++ b/dir/data.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>
@@ -100,6 +102,10 @@
 <tr>
 <td><code>/reactions/*.json</code></td>
 <td><a href="/reaction">Reaction</a></td>
+</tr>
+<tr>
+<td><code>/userlists/*.json</code></td>
+<td><a href="/userlist">Userlist</a></td>
 </tr>
 </tbody>
 </table>

--- a/dir/refs.html
+++ b/dir/refs.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/bookmarks.html
+++ b/docs/api/bookmarks.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/follows.html
+++ b/docs/api/follows.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/posts.html
+++ b/docs/api/posts.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/profiles.html
+++ b/docs/api/profiles.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/reactions.html
+++ b/docs/api/reactions.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/search.html
+++ b/docs/api/search.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/api/sitelists.html
+++ b/docs/api/sitelists.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Comments API | Unwalled.Garden</title>
+    <title>Sitelists API | Unwalled.Garden</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="/assets/styles.css">
     <link rel="stylesheet" href="/assets/syntax.css">
@@ -66,35 +66,34 @@
   </li>
 </ul>
       </nav>
-      <main><h2>Comments API</h2>
-<p>Comments are replies to content around the Web. They are threaded (meaning that all comments can reply to all other comments, forming a tree). Any URL can be the topic of a comment.</p>
+      <main><h2>Sitelists API</h2>
+<p>Sitelists are collections of sites. They can be used to share recommended follows, recommended apps, employee lists, and more.</p>
+<p>In addition to a title and description, sitelists have a <code>name</code> which determines the filename of the sitelist. A site cannot publish two sitelists with the same name.</p>
+<p>A sitelist should only include links to sites (not to files or pages).</p>
 <hr>
-<pre><code class="language-js"><span class="hljs-keyword">import</span> {comments} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
+<pre><code class="language-js"><span class="hljs-keyword">import</span> {sitelists} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
 
 <span class="hljs-comment">// read</span>
-<span class="hljs-keyword">await</span> comments.list({
-  <span class="hljs-attr">filters</span>: {authors, topics, visibility},
+<span class="hljs-keyword">await</span> sitelists.list({
+  <span class="hljs-attr">filters</span>: {authors, visibility},
   sortBy,
   offset,
   limit,
   reverse
 })
-<span class="hljs-keyword">await</span> comments.thread(topic, {
-  <span class="hljs-attr">filters</span>: {authors, visibility},
-  parent,
-  depth,
-  sortBy
-})
-<span class="hljs-keyword">await</span> comments.get(url)
+<span class="hljs-keyword">await</span> sitelists.get(author, name)
 
 <span class="hljs-comment">// write</span>
-<span class="hljs-keyword">await</span> comments.add(topic, {body, replyTo, visibility})
-<span class="hljs-keyword">await</span> comments.edit(url, {body, replyTo, visibility})
-<span class="hljs-keyword">await</span> comments.delete(url)
+<span class="hljs-keyword">await</span> sitelists.add({name, title, description, ext, visibility})
+<span class="hljs-keyword">await</span> sitelists.edit(name, {name, title, description, ext, visibility})
+<span class="hljs-keyword">await</span> sitelists.remove(name)
+<span class="hljs-keyword">await</span> sitelists.addSite(name, {url, title, description, type, ext})
+<span class="hljs-keyword">await</span> sitelists.editSite(name, url, {url, title, description, type, ext})
+<span class="hljs-keyword">await</span> sitelists.removeSite(name, url)
 </code></pre>
 <hr>
-<h3>Comment</h3>
-<p>The values returned by most comment functions will fit the following object shape:</p>
+<h3>SiteList</h3>
+<p>The values returned by sitelist functions will fit the following object shape:</p>
 <table>
 <thead>
 <tr>
@@ -107,37 +106,42 @@
 <tr>
 <td>url</td>
 <td><code>string</code></td>
-<td>The URL of the comment</td>
+<td>The URL of the sitelist</td>
 </tr>
 <tr>
-<td>topic</td>
+<td>name</td>
 <td><code>string</code></td>
-<td>The URL of the comment topic</td>
+<td>The name of the sitelist</td>
 </tr>
 <tr>
-<td>replyTo</td>
+<td>title</td>
 <td><code>string</code></td>
-<td>The URL of the parent comment</td>
+<td>The title of the sitelist</td>
 </tr>
 <tr>
-<td>body</td>
+<td>description</td>
 <td><code>string</code></td>
-<td>The text body of the comment</td>
+<td>The description of the sitelist</td>
+</tr>
+<tr>
+<td>sites</td>
+<td><code>SiteListItem[]</code></td>
+<td>The sites in the sitelist</td>
 </tr>
 <tr>
 <td>createdAt</td>
 <td><code>string</code></td>
-<td>The timestamp of when the comment claims it was created</td>
+<td>The timestamp of when the sitelist claims it was created</td>
 </tr>
 <tr>
 <td>updatedAt</td>
 <td><code>string</code></td>
-<td>The timestamp of when the comment claims it was last updated</td>
+<td>The timestamp of when the sitelist claims it was last updated</td>
 </tr>
 <tr>
 <td>author</td>
 <td><code>Object</code></td>
-<td>The comment author’s information</td>
+<td>The site that authored the sitelist</td>
 </tr>
 <tr>
 <td> url</td>
@@ -160,15 +164,20 @@
 <td></td>
 </tr>
 <tr>
+<td>ext</td>
+<td><code>Object</code></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
+</tr>
+<tr>
 <td>visibility</td>
 <td><code>string</code></td>
-<td>The <a href="/docs/common-fields#visibility">visibility</a> of the comment</td>
+<td>The <a href="/docs/common-fields#visibility">visibility</a> of the sitelist record</td>
 </tr>
 </tbody>
 </table>
 <hr>
-<h3>ThreadComment</h3>
-<p>The values returned by the <code>thread()</code> function will fit the following object shape:</p>
+<h3>SiteListItem</h3>
+<p>The <code>SiteList</code> includes an array of sites objects that fit this shape:</p>
 <table>
 <thead>
 <tr>
@@ -181,78 +190,33 @@
 <tr>
 <td>url</td>
 <td><code>string</code></td>
-<td>The URL of the comment</td>
+<td>The URL of the site</td>
 </tr>
 <tr>
-<td>topic</td>
+<td>title</td>
 <td><code>string</code></td>
-<td>The URL of the comment topic</td>
+<td>The title of the site</td>
 </tr>
 <tr>
-<td>replyTo</td>
+<td>description</td>
 <td><code>string</code></td>
-<td>The URL of the parent comment</td>
+<td>The description of the site</td>
 </tr>
 <tr>
-<td>replies</td>
-<td><code>ThreadComment[]</code></td>
-<td>The replies to the comment</td>
-</tr>
-<tr>
-<td>hasReplies</td>
-<td><code>boolean</code></td>
-<td>Does the comment have replies?</td>
-</tr>
-<tr>
-<td>body</td>
-<td><code>string</code></td>
-<td>The text body of the comment</td>
-</tr>
-<tr>
-<td>createdAt</td>
-<td><code>string</code></td>
-<td>The timestamp of when the comment claims it was created</td>
-</tr>
-<tr>
-<td>updatedAt</td>
-<td><code>string</code></td>
-<td>The timestamp of when the comment claims it was last updated</td>
-</tr>
-<tr>
-<td>author</td>
-<td><code>Object</code></td>
-<td>The comment author’s information</td>
-</tr>
-<tr>
-<td> url</td>
-<td><code>string</code></td>
-<td></td>
-</tr>
-<tr>
-<td> title</td>
-<td><code>string</code></td>
-<td></td>
-</tr>
-<tr>
-<td> description</td>
-<td><code>string</code></td>
-<td></td>
-</tr>
-<tr>
-<td> type</td>
+<td>type</td>
 <td><code>string[]</code></td>
-<td></td>
+<td>The type of the site</td>
 </tr>
 <tr>
-<td>visibility</td>
-<td><code>string</code></td>
-<td>The <a href="/docs/common-fields#visibility">visibility</a> of the comment</td>
+<td>ext</td>
+<td><code>Object</code></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 </tbody>
 </table>
 <hr>
 <h3>list(opts)</h3>
-<p>List the comments on the network.</p>
+<p>List sitelists on the network.</p>
 <table>
 <thead>
 <tr>
@@ -282,12 +246,6 @@
 <td>Site URLs</td>
 </tr>
 <tr>
-<td>  topics</td>
-<td><code>string|string[]</code></td>
-<td></td>
-<td>URLs</td>
-</tr>
-<tr>
 <td>  visibility</td>
 <td><code>string</code></td>
 <td><code>'all'</code></td>
@@ -296,8 +254,8 @@
 <tr>
 <td> sortBy</td>
 <td><code>string</code></td>
-<td><code>'createdAt'</code></td>
-<td>One of: <code>'createdAt'</code></td>
+<td><code>'topic'</code></td>
+<td>One of: <code>'topic'</code></td>
 </tr>
 <tr>
 <td> offset</td>
@@ -327,13 +285,13 @@
 </thead>
 <tbody>
 <tr>
-<td><code>Promise&lt;Comment[]&gt;</code></td>
+<td><code>Promise&lt;SiteList[]&gt;</code></td>
 </tr>
 </tbody>
 </table>
 <hr>
-<h3>thread(topic, opts)</h3>
-<p>Fetch the comment thread on a given topic.</p>
+<h3>get(author, name)</h3>
+<p>Get a sitelist by author and name.</p>
 <table>
 <thead>
 <tr>
@@ -345,144 +303,148 @@
 </thead>
 <tbody>
 <tr>
-<td>topic</td>
+<td>author</td>
 <td><code>string</code></td>
 <td></td>
-<td>URL (required)</td>
+<td>Site URL (required)</td>
 </tr>
 <tr>
-<td>opts</td>
+<td>name</td>
+<td><code>string</code></td>
+<td></td>
+<td>Sitelist name (required)</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;SiteList&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>add(sitelist)</h3>
+<p>Add a sitelist to the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>sitelist</td>
 <td><code>Object</code></td>
 <td></td>
 <td></td>
 </tr>
 <tr>
-<td> filters</td>
+<td> name</td>
+<td><code>string</code></td>
+<td></td>
+<td>The sitelist name (required)</td>
+</tr>
+<tr>
+<td> title</td>
+<td><code>string</code></td>
+<td></td>
+<td>The sitelist title</td>
+</tr>
+<tr>
+<td> description</td>
+<td><code>string</code></td>
+<td></td>
+<td>The sitelist description</td>
+</tr>
+<tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
+</tr>
+<tr>
+<td> <a href="/docs/common-fields#visibility">visibility</a></td>
+<td><code>string</code></td>
+<td><code>'public'</code></td>
+<td>One of: <code>'public'</code>, <code>'private'</code></td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;SiteList&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>edit(name, sitelist)</h3>
+<p>Edit a sitelist on the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td><code>string</code></td>
+<td></td>
+<td>The sitelist name (required)</td>
+</tr>
+<tr>
+<td>sitelist</td>
 <td><code>Object</code></td>
 <td></td>
 <td></td>
 </tr>
 <tr>
-<td>  authors</td>
-<td><code>string|string[]</code></td>
-<td></td>
-<td>Site URLs</td>
-</tr>
-<tr>
-<td>  visibility</td>
-<td><code>string</code></td>
-<td><code>'all'</code></td>
-<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
-</tr>
-<tr>
-<td> parent</td>
+<td> name</td>
 <td><code>string</code></td>
 <td></td>
-<td>The URL of comment in the thread</td>
+<td>The sitelist name</td>
 </tr>
 <tr>
-<td> depth</td>
-<td><code>number</code></td>
-<td></td>
-<td>A limit on the depth to recurse down the comment tree</td>
-</tr>
-<tr>
-<td> sortBy</td>
-<td><code>string</code></td>
-<td><code>'createdAt'</code></td>
-<td>One of: <code>'createdAt'</code></td>
-</tr>
-</tbody>
-</table>
-<table>
-<thead>
-<tr>
-<th>Returns</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>Promise&lt;ThreadComment[]&gt;</code></td>
-</tr>
-</tbody>
-</table>
-<p>If <code>depth</code> is specified, the <code>ThreadComment</code> objects at the depth limit will not have <code>replies</code> populated even if there are replies. You can check <code>hasReplies</code> to see if there are replies which were not fetched.</p>
-<p>You can specify the <code>parent</code> parameter to fetch a subtree of the thread.</p>
-<hr>
-<h3>get(url)</h3>
-<p>Get an individual comment by its URL.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Default</th>
-<th>Usage</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>url</td>
+<td> title</td>
 <td><code>string</code></td>
 <td></td>
-<td>Comment URL (required)</td>
+<td>The sitelist title</td>
 </tr>
-</tbody>
-</table>
-<table>
-<thead>
 <tr>
-<th>Returns</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>Promise&lt;Comment&gt;</code></td>
-</tr>
-</tbody>
-</table>
-<hr>
-<h3>add(topic, comment)</h3>
-<p>Add a comment to the current user’s site.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Default</th>
-<th>Usage</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>topic</td>
+<td> description</td>
 <td><code>string</code></td>
 <td></td>
-<td>Topic URL (required)</td>
+<td>The sitelist description</td>
 </tr>
 <tr>
-<td>comment</td>
-<td><code>string|Object</code></td>
+<td> ext</td>
+<td><code>Object</code></td>
 <td></td>
-<td>If a string, specifies the body (required)</td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
 </tr>
 <tr>
-<td> body</td>
-<td><code>string</code></td>
-<td></td>
-<td>The comment body (required)</td>
-</tr>
-<tr>
-<td> replyTo</td>
-<td><code>string</code></td>
-<td></td>
-<td>The URL of the comment being replied to</td>
-</tr>
-<tr>
-<td> visibility</td>
+<td> <a href="/docs/common-fields#visibility">visibility</a></td>
 <td><code>string</code></td>
 <td><code>'public'</code></td>
-<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
+<td>One of: <code>'public'</code>, <code>'private'</code></td>
 </tr>
 </tbody>
 </table>
@@ -494,17 +456,13 @@
 </thead>
 <tbody>
 <tr>
-<td><code>Promise&lt;Comment&gt;</code></td>
+<td><code>Promise&lt;SiteList&gt;</code></td>
 </tr>
 </tbody>
 </table>
-<h4>Example</h4>
-<pre><code class="language-js"><span class="hljs-keyword">await</span> comments.add(<span class="hljs-string">'dat://unwalled.garden'</span>, <span class="hljs-string">'What a great site!'</span>)
-<span class="hljs-keyword">await</span> comments.add(<span class="hljs-string">'dat://unwalled.garden'</span>, {<span class="hljs-attr">body</span>: <span class="hljs-string">'TODO: read this later'</span>, <span class="hljs-attr">visibility</span>: <span class="hljs-string">'private'</span>})
-</code></pre>
 <hr>
-<h3>edit(url, comment)</h3>
-<p>Edit a comment on the current user’s site.</p>
+<h3>remove(name)</h3>
+<p>Remove a sitelist from the current user’s site.</p>
 <table>
 <thead>
 <tr>
@@ -516,70 +474,10 @@
 </thead>
 <tbody>
 <tr>
-<td>url</td>
+<td>name</td>
 <td><code>string</code></td>
 <td></td>
-<td>The URL of the comment you want to edit (required)</td>
-</tr>
-<tr>
-<td>comment</td>
-<td><code>string|Object</code></td>
-<td></td>
-<td>If a string, specifies the body (required)</td>
-</tr>
-<tr>
-<td> body</td>
-<td><code>string</code></td>
-<td></td>
-<td>The comment body (required)</td>
-</tr>
-<tr>
-<td> replyTo</td>
-<td><code>string</code></td>
-<td></td>
-<td>The URL of the comment being replied to</td>
-</tr>
-<tr>
-<td> visibility</td>
-<td><code>string</code></td>
-<td><code>'public'</code></td>
-<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
-</tr>
-</tbody>
-</table>
-<table>
-<thead>
-<tr>
-<th>Returns</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>Promise&lt;Comment&gt;</code></td>
-</tr>
-</tbody>
-</table>
-<h4>Example</h4>
-<pre><code class="language-js"><span class="hljs-keyword">await</span> comments.edit(myComment.url, <span class="hljs-string">'Hello, world!!'</span>)
-</code></pre>
-<hr>
-<h3>delete(url)</h3>
-<p>Delete a comment on the current user’s site.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Default</th>
-<th>Usage</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>url</td>
-<td><code>string</code></td>
-<td></td>
-<td>The URL of the comment you want to delete (required)</td>
+<td>The sitelist name (required)</td>
 </tr>
 </tbody>
 </table>
@@ -596,6 +494,188 @@
 </tbody>
 </table>
 <hr>
+<h3>addSite(name, site)</h3>
+<p>Add a site to a sitelist on the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td><code>string</code></td>
+<td></td>
+<td>The sitelist name (required)</td>
+</tr>
+<tr>
+<td>site</td>
+<td><code>Object</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td> url</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site URL (required)</td>
+</tr>
+<tr>
+<td> title</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site title</td>
+</tr>
+<tr>
+<td> description</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site description</td>
+</tr>
+<tr>
+<td> type</td>
+<td><code>string[]</code></td>
+<td></td>
+<td>The site type</td>
+</tr>
+<tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;SiteList&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>editSite(name, url, site)</h3>
+<p>Edit a site in a sitelist on the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td><code>string</code></td>
+<td></td>
+<td>The sitelist name (required)</td>
+</tr>
+<tr>
+<td>url</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site URL (required)</td>
+</tr>
+<tr>
+<td>site</td>
+<td><code>Object</code></td>
+<td></td>
+<td></td>
+</tr>
+<tr>
+<td> url</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site URL</td>
+</tr>
+<tr>
+<td> title</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site title</td>
+</tr>
+<tr>
+<td> description</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site description</td>
+</tr>
+<tr>
+<td> type</td>
+<td><code>string[]</code></td>
+<td></td>
+<td>The site type</td>
+</tr>
+<tr>
+<td> ext</td>
+<td><code>Object</code></td>
+<td></td>
+<td>The <a href="/docs/how-to-extend-schemas">extension</a> object</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;SiteList&gt;</code></td>
+</tr>
+</tbody>
+</table>
+<hr>
+<h3>removeSite(name, site)</h3>
+<p>Remove a site from a sitelist on the current user’s site.</p>
+<table>
+<thead>
+<tr>
+<th>Param</th>
+<th>Type</th>
+<th>Default</th>
+<th>Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>name</td>
+<td><code>string</code></td>
+<td></td>
+<td>The sitelist name (required)</td>
+</tr>
+<tr>
+<td>url</td>
+<td><code>string</code></td>
+<td></td>
+<td>The site URL (required)</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Returns</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>Promise&lt;SiteList&gt;</code></td>
+</tr>
+</tbody>
+</table>
 </main>
     </div>
   </body>

--- a/docs/browser-integration.html
+++ b/docs/browser-integration.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/common-fields.html
+++ b/docs/common-fields.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/dat-primer.html
+++ b/docs/dat-primer.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/examples/one.html
+++ b/docs/examples/one.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/how-does-it-work.html
+++ b/docs/how-does-it-work.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/mounts.html
+++ b/docs/mounts.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/docs/why-not-rdf.html
+++ b/docs/why-not-rdf.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/follows.html
+++ b/follows.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -70,6 +71,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/person.html
+++ b/person.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/post.html
+++ b/post.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/reaction.html
+++ b/reaction.html
@@ -35,6 +35,7 @@
       <li><a href="/docs/api/posts">Posts</a></li>
       <li><a href="/docs/api/profiles">Profiles</a></li>
       <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
     </ul>
   </li>
 </ul>
@@ -47,6 +48,7 @@
       <li><a href="/person">Person</a></li>
       <li><a href="/post">Post</a></li>
       <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
       <li>dir<ul>
         <li><a href="/dir/data">Data</a></li>
         <li><a href="/dir/refs">Refs</a></li>

--- a/sitelist.html
+++ b/sitelist.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Sitelist (unwalled.garden/sitelist) | Unwalled.Garden</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="/assets/styles.css">
+    <link rel="stylesheet" href="/assets/syntax.css">
+  </head>
+  <body>
+    <h1><a href="/">Unwalled.Garden</a></h1>
+    <a class="nav-open"><img src="/assets/hamburger.svg"></a>
+    <div class="notice">Status: DRAFT. Part of the upcoming <a href="https://beakerbrowser.com">Beaker Browser</a> 0.9 release.</div>
+    <div class="page">
+      <nav>
+        <a class="nav-close"><img src="/assets/hamburger.svg"></a>
+        <ul>
+    <li>Docs
+      <ul>
+        <li><a href="/docs/how-does-it-work">How it works</a></li>
+        <li><a href="/docs/dat-primer">Dat protocol</a><ul>
+          <li><a href="/docs/mounts">Mounts</a></li>
+        </ul></li>
+        <li><a href="/docs/browser-integration">Browser integration</a></li>
+        <li><a href="/docs/common-fields">Common fields</a></li>
+        <li><a href="/docs/why-not-rdf">Why not RDF?</a></li>
+      </ul>
+    </li>
+  </ul>
+<ul>
+  <li>APIs
+    <ul>
+      <li><a href="/docs/api/bookmarks">Bookmarks</a></li>
+      <li><a href="/docs/api/comments">Comments</a></li>
+      <li><a href="/docs/api/follows">Follows</a></li>
+      <li><a href="/docs/api/posts">Posts</a></li>
+      <li><a href="/docs/api/profiles">Profiles</a></li>
+      <li><a href="/docs/api/reactions">Reactions</a></li>
+      <li><a href="/docs/api/sitelists">Sitelists</a></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Schemas
+    <ul>
+      <li><a href="/bookmark">Bookmark</a></li>
+      <li><a href="/comment">Comment</a></li>
+      <li><a href="/follows">Follows</a></li>
+      <li><a href="/person">Person</a></li>
+      <li><a href="/post">Post</a></li>
+      <li><a href="/reaction">Reaction</a></li>
+      <li><a href="/sitelist">Sitelist</a></li>
+      <li>dir<ul>
+        <li><a href="/dir/data">Data</a></li>
+        <li><a href="/dir/refs">Refs</a></li>
+      </ul></li>
+    </ul>
+  </li>
+</ul>
+<ul>
+  <li>Links
+    <ul>
+      <li><a href="https://github.com/beakerbrowser/unwalled.garden">Github Repo</a></li>
+      <li><a href="https://beakerbrowser.com">Beaker Browser</a></li>
+      <li><a href="https://dat.foundation">Dat protocol</a></li>
+    </ul>
+  </li>
+</ul>
+      </nav>
+      <main><h2>Sitelist <code>unwalled.garden/sitelist</code></h2>
+<hr>
+<ul>
+<li>File type</li>
+<li><strong>Description</strong>: A list of sites.</li>
+<li><strong>Path</strong>: <code>/.data/unwalled.garden/sitelists/*.json</code></li>
+</ul>
+<hr>
+<h4>Notes</h4>
+<p>The <code>name</code> field should be the same as the filename of the JSON file (minus the <code>.json</code> extension). A site cannot publish two sitelists with the same name.</p>
+<p>The <code>url</code> fields of the <code>sites</code> should point to the root resource. Paths should be ignored. (It’s a site list, not a link list!)</p>
+<h4>Example</h4>
+<pre><code class="language-json">{
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/sitelist"</span>,
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"my-friends"</span>,
+  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Friends"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"People I know from real life"</span>,
+  <span class="hljs-attr">"sites"</span>: [
+    {
+      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"dat://43dfc9f23fdded8cc7c01c71c0702a0529130af0258e7fb30bf5a0a3f73d69b3"</span>,
+      <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Alice"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Advocate of the free and open web"</span>,
+      <span class="hljs-attr">"type"</span>: [<span class="hljs-string">"unwalled.garden/person"</span>]
+    },
+    {
+      <span class="hljs-attr">"url"</span>: <span class="hljs-string">"dat://db10d577c44118c47fb76a69026cba01e90c5919d636b2b6e6ffac3eac52e8fa"</span>,
+      <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Bob"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Animal lover, career mortician"</span>,
+      <span class="hljs-attr">"type"</span>: [<span class="hljs-string">"unwalled.garden/person"</span>]
+    }
+  ],
+  <span class="hljs-attr">"createdAt"</span>: <span class="hljs-string">"2018-12-07T02:52:11.947Z"</span>,
+  <span class="hljs-attr">"updatedAt"</span>: <span class="hljs-string">"2018-12-21T06:22:15.401Z"</span>
+}
+</code></pre>
+<h4>Schema</h4>
+<pre><code class="language-json">{
+  <span class="hljs-attr">"$schema"</span>: <span class="hljs-string">"http://json-schema.org/draft-07/schema#"</span>,
+  <span class="hljs-attr">"$id"</span>: <span class="hljs-string">"dat://unwalled.garden/sitelist.json"</span>,
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Sitelist"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A list of data subscriptions."</span>,
+  <span class="hljs-attr">"required"</span>: [
+    <span class="hljs-string">"type"</span>,
+    <span class="hljs-string">"name"</span>,
+    <span class="hljs-string">"sites"</span>
+  ],
+  <span class="hljs-attr">"properties"</span>: {
+    <span class="hljs-attr">"type"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"const"</span>: <span class="hljs-string">"unwalled.garden/sitelist"</span>
+    },
+    <span class="hljs-attr">"name"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"pattern"</span>: <span class="hljs-string">"^[A-Za-z][A-Za-z0-9-_?]*$"</span>
+    },
+    <span class="hljs-attr">"title"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    },
+    <span class="hljs-attr">"description"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+    },
+    <span class="hljs-attr">"sites"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+      <span class="hljs-attr">"items"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+        <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"url"</span>],
+        <span class="hljs-attr">"properties"</span>: {
+          <span class="hljs-attr">"url"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+            <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>
+          },
+          <span class="hljs-attr">"title"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+          },
+          <span class="hljs-attr">"description"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+          },
+          <span class="hljs-attr">"type"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+            <span class="hljs-attr">"items"</span>: {
+              <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+            }
+          },
+          <span class="hljs-attr">"ext"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>
+          }
+        }
+      }
+    },
+    <span class="hljs-attr">"createdAt"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>
+    },
+    <span class="hljs-attr">"updatedAt"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>
+    },
+    <span class="hljs-attr">"ext"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>
+    }
+  }
+}
+</code></pre>
+</main>
+    </div>
+  </body>
+  <script type="module" src="/assets/admin.js"></script>
+  <script>
+    document.querySelector('.nav-open').addEventListener('click', e => {
+      document.querySelector('nav').classList.add('show')
+    })
+    document.querySelector('.nav-close').addEventListener('click', e => {
+      document.querySelector('nav').classList.remove('show')
+    })
+  </script>
+</html>


### PR DESCRIPTION
Adds "sitelists". Example sitelist:

```json
{
  "type": "unwalled.garden/sitelist",
  "name": "my-friends",
  "title": "Friends",
  "description": "People I know from real life",
  "sites": [
    {
      "url": "dat://43dfc9f23fdded8cc7c01c71c0702a0529130af0258e7fb30bf5a0a3f73d69b3",
      "title": "Alice",
      "description": "Advocate of the free and open web",
      "type": ["unwalled.garden/person"]
    },
    {
      "url": "dat://db10d577c44118c47fb76a69026cba01e90c5919d636b2b6e6ffac3eac52e8fa",
      "title": "Bob",
      "description": "Animal lover, career mortician",
      "type": ["unwalled.garden/person"]
    }
  ],
  "createdAt": "2018-12-07T02:52:11.947Z",
  "updatedAt": "2018-12-21T06:22:15.401Z"
}
```

Sitelists are collections of sites. They can be used to share recommended follows, recommended apps, employee lists, and more. I figure they'd be good to have early as a way to improve discovery.