### PR TITLE
Expand the .refs directory to 3 subdirs: follows, authored, and authors

### DIFF
--- a/_md/dir/data.md
+++ b/_md/dir/data.md
@@ -12,9 +12,9 @@
 
 |Path|Type|
 |-|-|
-|`/bookmarks/*.json`|[Bookmark](/bookmark)|
-|`/comments/*.json`|[Comment](/comment)|
-|`/follows.json`|[Follows](/follows)|
-|`/posts/*.json`|[Post](/post)|
-|`/reactions/*.json`|[Reaction](/reaction)|
-|`/votes/*.json`|[Vote](/vote)|
+|`/.data/unwalled.garden/bookmarks/*.json`|[Bookmark](/bookmark)|
+|`/.data/unwalled.garden/comments/*.json`|[Comment](/comment)|
+|`/.data/unwalled.garden/follows.json`|[Follows](/follows)|
+|`/.data/unwalled.garden/posts/*.json`|[Post](/post)|
+|`/.data/unwalled.garden/reactions/*.json`|[Reaction](/reaction)|
+|`/.data/unwalled.garden/votes/*.json`|[Vote](/vote)|

--- a/_md/dir/refs.md
+++ b/_md/dir/refs.md
@@ -10,12 +10,22 @@
 
 ### Notes
 
-The "Refs" directory contains mounts to Dat sites which a reader might want to access in order to render content. It should contain mounts to all [followed sites](/follows).
+The "Refs" directory contains mounts to referenced Dat sites.
 
-The names of the mounts MUST be the public key of the mounted site. A DNS shortname can not be used. This is to avoid incorrect DNS mappings.
+The `follows` folder is used by the [follows record](/follows) as a way to give fast access to the `dat.json` of followed users.
+
+The `authored` folder acts as a listing of sites published by a [person](/person). Readers can create a list of published sites by reading the `dat.json` of each mounted dat. (There is no JSON record of authored sites; just this .refs directory.)
+
+The `authors` folder lists the authors of a non-person site.
+
+Readers should confirm authorship of sites by looking for the bidirectional authors/authored mounts: the author will be mounted in the `.ref/authors` of the site, while the site will be listed in the `.ref/authored` of the author. If this bidirectional mount does not exist, no authorship information should be displayed to the user as it might be a false claim of authorship.
+
+The names of the mounts must be the public key of the mounted site. A DNS shortname can not be used. This is to avoid incorrect DNS mappings.
 
 ### File structure
 
-|Path|Type|
+|Path|Description|
 |-|-|
-|`*`|Mount to a Dat hyperdrive.|
+|`/.refs/follows/*`|Mounts pointing to all followed sites.|
+|`/.refs/authored/*`|Mounts pointing to all published sites.|
+|`/.refs/authors/*`|Mounts pointing to the authors of a site.|

--- a/_md/dir/refs.md
+++ b/_md/dir/refs.md
@@ -20,7 +20,7 @@ The `authors` folder lists the authors of a non-person site.
 
 Readers should confirm authorship of sites by looking for the bidirectional authors/authored mounts: the author will be mounted in the `.ref/authors` of the site, while the site will be listed in the `.ref/authored` of the author. If this bidirectional mount does not exist, no authorship information should be displayed to the user as it might be a false claim of authorship.
 
-The names of the mounts must be the public key of the mounted site. A DNS shortname can not be used. This is to avoid incorrect DNS mappings.
+The names of the mounts in the `.ref` folders can be user-friendly shortnames. Readers should read the mount target field to find specific sites.
 
 ### File structure
 

--- a/_md/person.md
+++ b/_md/person.md
@@ -35,4 +35,5 @@ Example:
 |`/dat.json`|Standard dat.json file|
 |`/thumb.(png|jpg|jpeg)`|Profile picture|
 |`/.data/unwalled.garden`|[Data directory](/dir/data)|
-|`/.refs`|[Refs directory](/dir/data)|
+|`/.refs/follows`|[Refs "followed sites" directory](/dir/refs)|
+|`/.refs/authored`|[Refs "authored sites" directory](/dir/refs)|

--- a/_md/vote.md
+++ b/_md/vote.md
@@ -8,7 +8,7 @@
 
 ---
 
-#### Examples
+#### Example
 
 ```json
 {

--- a/dir/data.html
+++ b/dir/data.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
@@ -86,27 +85,27 @@
 </thead>
 <tbody>
 <tr>
-<td><code>/bookmarks/*.json</code></td>
+<td><code>/.data/unwalled.garden/bookmarks/*.json</code></td>
 <td><a href="/bookmark">Bookmark</a></td>
 </tr>
 <tr>
-<td><code>/comments/*.json</code></td>
+<td><code>/.data/unwalled.garden/comments/*.json</code></td>
 <td><a href="/comment">Comment</a></td>
 </tr>
 <tr>
-<td><code>/follows.json</code></td>
+<td><code>/.data/unwalled.garden/follows.json</code></td>
 <td><a href="/follows">Follows</a></td>
 </tr>
 <tr>
-<td><code>/posts/*.json</code></td>
+<td><code>/.data/unwalled.garden/posts/*.json</code></td>
 <td><a href="/post">Post</a></td>
 </tr>
 <tr>
-<td><code>/reactions/*.json</code></td>
+<td><code>/.data/unwalled.garden/reactions/*.json</code></td>
 <td><a href="/reaction">Reaction</a></td>
 </tr>
 <tr>
-<td><code>/votes/*.json</code></td>
+<td><code>/.data/unwalled.garden/votes/*.json</code></td>
 <td><a href="/vote">Vote</a></td>
 </tr>
 </tbody>

--- a/dir/refs.html
+++ b/dir/refs.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
@@ -77,20 +76,32 @@
 </ul>
 <hr>
 <h3>Notes</h3>
-<p>The “Refs” directory contains mounts to Dat sites which a reader might want to access in order to render content. It should contain mounts to all <a href="/follows">followed sites</a>.</p>
-<p>The names of the mounts MUST be the public key of the mounted site. A DNS shortname can not be used. This is to avoid incorrect DNS mappings.</p>
+<p>The “Refs” directory contains mounts to referenced Dat sites.</p>
+<p>The <code>follows</code> folder is used by the <a href="/follows">follows record</a> as a way to give fast access to the <code>dat.json</code> of followed users.</p>
+<p>The <code>authored</code> folder acts as a listing of sites published by a <a href="/person">person</a>. Readers can create a list of published sites by reading the <code>dat.json</code> of each mounted dat. (There is no JSON record of authored sites; just this .refs directory.)</p>
+<p>The <code>authors</code> folder lists the authors of a non-person site.</p>
+<p>Readers should confirm authorship of sites by looking for the bidirectional authors/authored mounts: the author will be mounted in the <code>.ref/authors</code> of the site, while the site will be listed in the <code>.ref/authored</code> of the author. If this bidirectional mount does not exist, no authorship information should be displayed to the user as it might be a false claim of authorship.</p>
+<p>The names of the mounts must be the public key of the mounted site. A DNS shortname can not be used. This is to avoid incorrect DNS mappings.</p>
 <h3>File structure</h3>
 <table>
 <thead>
 <tr>
 <th>Path</th>
-<th>Type</th>
+<th>Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td><code>*</code></td>
-<td>Mount to a Dat hyperdrive.</td>
+<td><code>/.refs/follows/*</code></td>
+<td>Mounts pointing to all followed sites.</td>
+</tr>
+<tr>
+<td><code>/.refs/authored/*</code></td>
+<td>Mounts pointing to all published sites.</td>
+</tr>
+<tr>
+<td><code>/.refs/authors/*</code></td>
+<td>Mounts pointing to the authors of a site.</td>
 </tr>
 </tbody>
 </table>

--- a/dir/refs.html
+++ b/dir/refs.html
@@ -81,7 +81,7 @@
 <p>The <code>authored</code> folder acts as a listing of sites published by a <a href="/person">person</a>. Readers can create a list of published sites by reading the <code>dat.json</code> of each mounted dat. (There is no JSON record of authored sites; just this .refs directory.)</p>
 <p>The <code>authors</code> folder lists the authors of a non-person site.</p>
 <p>Readers should confirm authorship of sites by looking for the bidirectional authors/authored mounts: the author will be mounted in the <code>.ref/authors</code> of the site, while the site will be listed in the <code>.ref/authored</code> of the author. If this bidirectional mount does not exist, no authorship information should be displayed to the user as it might be a false claim of authorship.</p>
-<p>The names of the mounts must be the public key of the mounted site. A DNS shortname can not be used. This is to avoid incorrect DNS mappings.</p>
+<p>The names of the mounts in the <code>.ref</code> folders can be user-friendly shortnames. Readers should read the mount target field to find specific sites.</p>
 <h3>File structure</h3>
 <table>
 <thead>

--- a/docs/browser-integration.html
+++ b/docs/browser-integration.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>

--- a/docs/common-fields.html
+++ b/docs/common-fields.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>

--- a/docs/dat-primer.html
+++ b/docs/dat-primer.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>

--- a/docs/examples/one.html
+++ b/docs/examples/one.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>

--- a/docs/how-does-it-work.html
+++ b/docs/how-does-it-work.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>

--- a/docs/mounts.html
+++ b/docs/mounts.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>

--- a/docs/why-not-rdf.html
+++ b/docs/why-not-rdf.html
@@ -18,7 +18,6 @@
       <ul>
         <li><a href="/docs/how-does-it-work">How it works</a><ul>
           <li><a href="/docs/common-fields">Common fields</a></li>
-          <li><a href="/docs/how-to-extend-schemas">Extending schemas</a></li>
           <li><a href="/docs/browser-integration">Browser integration</a></li>
         </ul></li>
         <li><a href="/docs/dat-primer">Dat protocol</a><ul>
@@ -120,18 +119,6 @@ paul[<span class="hljs-string">'dat://websites.com/manifest#title'</span>] = <sp
 <p>Which makes our code much cleaner:</p>
 <pre><code class="language-js">paul.title = <span class="hljs-string">'Paul Frazee'</span>
 paul.description = <span class="hljs-string">'Beaker guy'</span>
-</code></pre>
-<p>If schemas <em>must</em> be combined, only then might we use URL keys (see <a href="/docs/how-to-extend-schemas">How to extend the schemas</a>):</p>
-<pre><code class="language-json">{
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"websites.com/manifest"</span>,
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Paul Frazee"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Beaker guy"</span>,
-  <span class="hljs-attr">"ext"</span>: {
-    <span class="hljs-attr">"social.com/follows"</span>: {
-      <span class="hljs-attr">"urls"</span>: [<span class="hljs-string">"dat://alice.com"</span>, <span class="hljs-string">"dat://bob.com"</span>]
-    }
-  }
-}
 </code></pre>
 <p>The Unwalled.Garden philosophy about RDF is <a href="https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it">YAGNI (You Ain’t Gonna Need It)</a>. We see RDF’s complexity as a turn-off to developers and something we should try to avoid if we can.</p>
 </main>

--- a/person.html
+++ b/person.html
@@ -128,8 +128,12 @@
 <td><a href="/dir/data">Data directory</a></td>
 </tr>
 <tr>
-<td><code>/.refs</code></td>
-<td><a href="/dir/data">Refs directory</a></td>
+<td><code>/.refs/follows</code></td>
+<td><a href="/dir/refs">Refs “followed sites” directory</a></td>
+</tr>
+<tr>
+<td><code>/.refs/authored</code></td>
+<td><a href="/dir/refs">Refs “authored sites” directory</a></td>
 </tr>
 </tbody>
 </table>

--- a/vote.html
+++ b/vote.html
@@ -75,7 +75,7 @@
 <li><strong>Path</strong>: <code>/.data/unwalled.garden/votes/*.json</code></li>
 </ul>
 <hr>
-<h4>Examples</h4>
+<h4>Example</h4>
 <pre><code class="language-json">{
   <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/vote"</span>,
   <span class="hljs-attr">"topic"</span>: <span class="hljs-string">"dat://beakerbrowser.com"</span>,


### PR DESCRIPTION
This PR re-arranges the `.refs` folder to contain three subfolders, `follows`, `authored`, and `authors`.

The `follows` folder contains mounts that point to followed sites. This is to enable fast lookups of their dat.jsons.

The `authored` folder contains sites which have been published by a user.

The `authors` folder contains a mount to the author(s) of a non-person site.

Note: mounts are basically a way to do fast denormalized lookups to other sites. They enable clients to read authenticated and up-to-date information without having to hit the DHT.