### PR TITLE
Websites and restructure

### DIFF
--- a/_md/api/follows.md
+++ b/_md/api/follows.md
@@ -31,17 +31,17 @@ The values returned by follow functions will fit the following object shape:
 
 |Attribute|Type|Usage|
 |-|-|-|
-|author</var>|`Object`|The site doing the following|
-|&emsp;url</var>|`string`||
-|&emsp;title</var>|`string`||
-|&emsp;description</var>|`string`||
-|&emsp;type</var>|`string[]`||
-|topic</var>|`Object`|The site being followed|
-|&emsp;url</var>|`string`||
-|&emsp;title</var>|`string`||
-|&emsp;description</var>|`string`||
-|&emsp;type</var>|`string[]`||
-|visibility</var>|`string`|The [visibility](/docs/common-fields#visibility) of the "follow" record|
+|author|`Object`|The site doing the following|
+|&emsp;url|`string`||
+|&emsp;title|`string`||
+|&emsp;description|`string`||
+|&emsp;type|`string[]`||
+|topic|`Object`|The site being followed|
+|&emsp;url|`string`||
+|&emsp;title|`string`||
+|&emsp;description|`string`||
+|&emsp;type|`string[]`||
+|visibility|`string`|The [visibility](/docs/common-fields#visibility) of the "follow" record|
 
 ---
 

--- a/_md/api/reactions.md
+++ b/_md/api/reactions.md
@@ -37,12 +37,12 @@ The values returned by reaction functions will fit the following object shape:
 |url|`string`|The URL of the reaction record|
 |topic|`string`|The URL that the reaction is attached to|
 |phrases|`string[]`|The phrases in the reaction|
-|author</var>|`Object`|The site that authored the reaction|
-|&emsp;url</var>|`string`||
-|&emsp;title</var>|`string`||
-|&emsp;description</var>|`string`||
-|&emsp;type</var>|`string[]`||
-|visibility</var>|`string`|The [visibility](/docs/common-fields#visibility) of the reaction|
+|author|`Object`|The site that authored the reaction|
+|&emsp;url|`string`||
+|&emsp;title|`string`||
+|&emsp;description|`string`||
+|&emsp;type|`string[]`||
+|visibility|`string`|The [visibility](/docs/common-fields#visibility) of the reaction|
 
 ---
 
@@ -54,11 +54,11 @@ The values returned by `tabulate()` will fit the following object shape:
 |-|-|-|
 |topic|`string`|The URL that the reaction is attached to|
 |phrase|`string`|The phrase in the reaction|
-|authors</var>|`Object[]`|The sites that authored the reaction|
-|&emsp;url</var>|`string`||
-|&emsp;title</var>|`string`||
-|&emsp;description</var>|`string`||
-|&emsp;type</var>|`string[]`||
+|authors|`Object[]`|The sites that authored the reaction|
+|&emsp;url|`string`||
+|&emsp;title|`string`||
+|&emsp;description|`string`||
+|&emsp;type|`string[]`||
 
 ---
 

--- a/_md/api/websites.md
+++ b/_md/api/websites.md
@@ -1,0 +1,94 @@
+## Websites API
+
+An API for websites that have been saved locally and/or published on the network.
+
+---
+
+```js
+import { websites } from 'dat://unwalled.garden/index.js'
+
+// read
+await websites.list({
+  filters: {authors, hrefs, isSaved, isHosting, visibility},
+  sortBy,
+  offset,
+  limit,
+  reverse
+})
+
+// write
+await websites.configure(href, {isSaved, isHosting, visibility})
+```
+
+---
+
+### Website
+
+The values returned by website functions will fit the following object shape:
+
+|Attribute|Type|Usage|
+|-|-|-|
+|author|`Object`|The site that published the website|
+|&emsp;url|`string`||
+|&emsp;title|`string`||
+|&emsp;description|`string`||
+|&emsp;type|`string[]`||
+|href|`string`|The URL of the published website|
+|title|`string`|The title of the published website|
+|description|`string`|The description of the published website|
+|isSaved|`boolean`|Has the local user saved the website? **(private)**|
+|isHosting|`boolean`|Is the local user hosting the website? **(private)**|
+|visibility|`string`|The [visibility](/docs/common-fields#visibility) of the website and its record|
+
+The fields marked **(private)** will only show on the local user's records. 
+
+---
+
+### Notes
+
+Websites are part of the user's personal library. The canonical record of a saved website is stored privately. If the visibility is "public" then a link-entry will also be added to the [public Links record](/links) at `/.data/websites.json`.
+
+Thumbnails of published websites should be published at `/.data/thumbs/websites/` using the domain name as the filename.
+
+---
+
+### list(opts)
+
+List websites by that are saved locally or published by authors.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|opts|`Object`|||
+|&emsp;filters|`Object`|||
+|&emsp;&emsp;authors|`string|string[]`||Author-site URLs|
+|&emsp;&emsp;hrefs|`string|string[]`||Website URLs|
+|&emsp;&emsp;isSaved|`boolean`||Has the local user saved the website?|
+|&emsp;&emsp;isHosting|`boolean`||Is the local user hosting the website?|
+|&emsp;&emsp;visibility|`string`|`'all'`|See [visibility](/docs/common-fields#visibility)|
+|&emsp;sortBy|`string`|`'topic'`|One of: `'topic'`|
+|&emsp;offset|`number`|0||
+|&emsp;limit|`number`|||
+|&emsp;reverse|`boolean`|`false`||
+
+|Returns|
+|-|
+|`Promise<Website[]>`|
+
+---
+
+### configure(href, opts)
+
+Configure a website in the local user's library.
+
+|Param|Type|Default|Usage|
+|-|-|-|-|
+|href|`string`||Website URL (required)|
+|opts|`Object`|||
+|&emsp;isSaved|`boolean`||Save the website to the local user's library?|
+|&emsp;isHosting|`boolean`||Host the website using the local user's devices?|
+|&emsp;[visibility](/docs/common-fields#visibility)|`string`||One of: `'public'`, `'unlisted'`, `'private'`|
+
+|Returns|
+|-|
+|`Promise<void>`|
+

--- a/_md/dir/data.md
+++ b/_md/dir/data.md
@@ -4,7 +4,7 @@
 
  - Folder type
  - **Description**: Contains the unwalled.garden record files.
- - **Path**: `/.data/unwalled.garden`
+ - **Path**: `/.data`
 
 ---
 
@@ -12,9 +12,17 @@
 
 |Path|Type|
 |-|-|
-|`/.data/unwalled.garden/bookmarks/*.json`|[Bookmark](/bookmark)|
-|`/.data/unwalled.garden/comments/*.json`|[Comment](/comment)|
-|`/.data/unwalled.garden/follows.json`|[Follows](/follows)|
-|`/.data/unwalled.garden/statuses/*.json`|[Status](/status)|
-|`/.data/unwalled.garden/reactions/*.json`|[Reaction](/reaction)|
-|`/.data/unwalled.garden/votes/*.json`|[Vote](/vote)|
+|`/.data/bookmarks/*.json`|[Bookmark](/bookmark)|
+|`/.data/comments/*.json`|[Comment](/comment)|
+|`/.data/follows.json`|[Follows](/follows)|
+|`/.data/statuses/*.json`|[Status](/status)|
+|`/.data/reactions/*.json`|[Reaction](/reaction)|
+|`/.data/thumbs`|Images (Thumbnails)|
+|`/.data/votes/*.json`|[Vote](/vote)|
+|`/.data/websites.json`|[Links](/links)|
+
+The `thumbs` folder includes the following structure:
+
+|Path|Purpose|
+|-|-|
+|`/.data/thumbs/websites/*.(png|jpg|jpeg)`|For website records|

--- a/_md/dir/refs.md
+++ b/_md/dir/refs.md
@@ -14,12 +14,6 @@ The "Refs" directory contains mounts to referenced Dat sites.
 
 The `follows` folder is used by the [follows record](/follows) as a way to give fast access to the `dat.json` of followed users.
 
-The `authored` folder acts as a listing of sites published by a [person](/person). Readers can create a list of published sites by reading the `dat.json` of each mounted dat. (There is no JSON record of authored sites; just this .refs directory.)
-
-The `authors` folder lists the authors of a non-person site.
-
-Readers should confirm authorship of sites by looking for the bidirectional authors/authored mounts: the author will be mounted in the `.ref/authors` of the site, while the site will be listed in the `.ref/authored` of the author. If this bidirectional mount does not exist, no authorship information should be displayed to the user as it might be a false claim of authorship.
-
 The names of the mounts in the `.ref` folders can be user-friendly shortnames. Readers should read the mount target field to find specific sites.
 
 ### File structure
@@ -27,5 +21,3 @@ The names of the mounts in the `.ref` folders can be user-friendly shortnames. R
 |Path|Description|
 |-|-|
 |`/.refs/follows/*`|Mounts pointing to all followed sites.|
-|`/.refs/authored/*`|Mounts pointing to all published sites.|
-|`/.refs/authors/*`|Mounts pointing to the authors of a site.|

--- a/_md/docs/common-fields.md
+++ b/_md/docs/common-fields.md
@@ -2,17 +2,18 @@
 
 ### <span id="visibility">visibility</span>
 
-The <var>visibility</var> field indicates who will be given access to the record. It currently has two possible values:
+The <var>visibility</var> field indicates who will be given access to some information. It currently has three possible values:
 
- - `'private'` The record is only accessible on the local user's devices. It is not shared with anyone.
- - `'public'` The record is published publicly and can be accessed by anyone.
+ - `'private'` The info is only accessible on the local user's devices. It is not shared with anyone.
+ - `'unlisted'` The info is accessible on the network by anyone but has not been published on the author's site.
+ - `'public'` The info is published publicly and can be accessed by anyone.
 
 When used as a query parameter, the field can also have the following value:
 
- - `'all'` Include both private and public records.
+ - `'all'` Include all kinds of records.
 
 #### How does it work?
 
 A user has two Dat hyperdrives: a public and a private. They both possess the [Data directory](/dir/data) in roughly the same location. In [Beaker](https://beakerbrowser.com), the private drive acts as the "root" of the user's filesystem, and the public drive is [mounted](/docs/mounts) to `/public` on the private drive.
 
-The private drive is kept off the network. When <var>visibility</var> is set to `'private'`, the record is written there. When set to `'public'`, it's written to the public drive.
+The private drive is kept off the network. When <var>visibility</var> is set to `'private'`, the record is written there. When set to `'public'`, it's written to the public drive. The `'unlisted'` value typically applies to separate dats that the user has created (such as [Websites](/api/websites)).

--- a/_md/docs/how-does-it-work.md
+++ b/_md/docs/how-does-it-work.md
@@ -27,10 +27,10 @@ All files are placed at predefined paths. An example site might look like this:
 |URL|Type|
 |-|-|
 |`dat://bob.com`|[Person](/person)|
-|`dat://bob.com/.data/unwalled.garden`|[Data directory](/dir/data)
-|`dat://bob.com/.data/unwalled.garden/statuses/hello.json`|[Status](/status)
-|`dat://bob.com/.data/unwalled.garden/reactions/1.json`|[Reaction](/reaction)
-|`dat://bob.com/.data/unwalled.garden/comments/1.json`|[Comment](/comment)
+|`dat://bob.com/.data`|[Data directory](/dir/data)
+|`dat://bob.com/.data/statuses/hello.json`|[Status](/status)
+|`dat://bob.com/.data/reactions/1.json`|[Reaction](/reaction)
+|`dat://bob.com/.data/comments/1.json`|[Comment](/comment)
 
 This site identifies as a [Person](/person) and it includes a [Status](/status), [Reaction](/reaction), and [Comment](/comment). A reader will crawl the website looking for these files to sync into its local database.
 

--- a/_md/links.md
+++ b/_md/links.md
@@ -1,0 +1,74 @@
+## Links `unwalled.garden/links`
+
+---
+
+ - File type
+ - **Description**: A list of links.
+
+---
+
+#### Notes
+
+This is a general-purpose schema that can be used in a number of different contexts.
+For example, the [Websites API](/api/websites) uses it to list published websites at `/.data/websites.json`.
+
+#### Example
+
+```json
+{
+  "type": "unwalled.garden/links",
+  "links": [
+    {
+      "href": "dat://pfrazee.com",
+      "title": "Paul Frazee",
+      "description": "Beaker guy",
+    },
+    {
+      "href": "dat://43dfc9f23fdded8cc7c01c71c0702a0529130af0258e7fb30bf5a0a3f73d69b3",
+      "title": "Unwalled Garden"
+    }
+  ]
+}
+```
+
+#### Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/links.json",
+  "type": "object",
+  "title": "Links",
+  "description": "A list of links.",
+  "required": [
+    "type",
+    "links"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The object's type",
+      "const": "unwalled.garden/links"
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["href"],
+        "properties": {
+          "href": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/_md/person.md
+++ b/_md/person.md
@@ -34,6 +34,5 @@ Example:
 |-|-|
 |`/dat.json`|Standard dat.json file|
 |`/thumb.(png|jpg|jpeg)`|Profile picture|
-|`/.data/unwalled.garden`|[Data directory](/dir/data)|
-|`/.refs/follows`|[Refs "followed sites" directory](/dir/refs)|
-|`/.refs/authored`|[Refs "authored sites" directory](/dir/refs)|
+|`/.data`|[Data directory](/dir/data)|
+|`/.refs`|[Refs directory](/dir/refs)|

--- a/api/bookmarks.html
+++ b/api/bookmarks.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/api/comments.html
+++ b/api/comments.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/api/follows.html
+++ b/api/follows.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/api/follows.html
+++ b/api/follows.html
@@ -100,57 +100,57 @@
 </thead>
 <tbody>
 <tr>
-<td>author</var></td>
+<td>author</td>
 <td><code>Object</code></td>
 <td>The site doing the following</td>
 </tr>
 <tr>
-<td> url</var></td>
+<td> url</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> title</var></td>
+<td> title</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> description</var></td>
+<td> description</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> type</var></td>
+<td> type</td>
 <td><code>string[]</code></td>
 <td></td>
 </tr>
 <tr>
-<td>topic</var></td>
+<td>topic</td>
 <td><code>Object</code></td>
 <td>The site being followed</td>
 </tr>
 <tr>
-<td> url</var></td>
+<td> url</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> title</var></td>
+<td> title</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> description</var></td>
+<td> description</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> type</var></td>
+<td> type</td>
 <td><code>string[]</code></td>
 <td></td>
 </tr>
 <tr>
-<td>visibility</var></td>
+<td>visibility</td>
 <td><code>string</code></td>
 <td>The <a href="/docs/common-fields#visibility">visibility</a> of the “follow” record</td>
 </tr>

--- a/api/profiles.html
+++ b/api/profiles.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/api/reactions.html
+++ b/api/reactions.html
@@ -117,32 +117,32 @@
 <td>The phrases in the reaction</td>
 </tr>
 <tr>
-<td>author</var></td>
+<td>author</td>
 <td><code>Object</code></td>
 <td>The site that authored the reaction</td>
 </tr>
 <tr>
-<td> url</var></td>
+<td> url</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> title</var></td>
+<td> title</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> description</var></td>
+<td> description</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> type</var></td>
+<td> type</td>
 <td><code>string[]</code></td>
 <td></td>
 </tr>
 <tr>
-<td>visibility</var></td>
+<td>visibility</td>
 <td><code>string</code></td>
 <td>The <a href="/docs/common-fields#visibility">visibility</a> of the reaction</td>
 </tr>
@@ -171,27 +171,27 @@
 <td>The phrase in the reaction</td>
 </tr>
 <tr>
-<td>authors</var></td>
+<td>authors</td>
 <td><code>Object[]</code></td>
 <td>The sites that authored the reaction</td>
 </tr>
 <tr>
-<td> url</var></td>
+<td> url</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> title</var></td>
+<td> title</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> description</var></td>
+<td> description</td>
 <td><code>string</code></td>
 <td></td>
 </tr>
 <tr>
-<td> type</var></td>
+<td> type</td>
 <td><code>string[]</code></td>
 <td></td>
 </tr>

--- a/api/reactions.html
+++ b/api/reactions.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/api/votes.html
+++ b/api/votes.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/api/websites.html
+++ b/api/websites.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Statuses API | Unwalled.Garden</title>
+    <title>Websites API | Unwalled.Garden</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="/assets/styles.css">
     <link rel="stylesheet" href="/assets/syntax.css">
@@ -69,29 +69,26 @@
   </li>
 </ul>
       </nav>
-      <main><h2>Statuses API</h2>
-<p>Statuses are blurbs of content that’s broadcasted on a feed. They’re sometimes known as “status updates.” The character limit is 1,000,000 characters.</p>
+      <main><h2>Websites API</h2>
+<p>An API for websites that have been saved locally and/or published on the network.</p>
 <hr>
-<pre><code class="language-js"><span class="hljs-keyword">import</span> {statuses} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
+<pre><code class="language-js"><span class="hljs-keyword">import</span> { websites } <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
 
 <span class="hljs-comment">// read</span>
-<span class="hljs-keyword">await</span> statuses.list({
-  <span class="hljs-attr">filters</span>: {authors, visibility},
+<span class="hljs-keyword">await</span> websites.list({
+  <span class="hljs-attr">filters</span>: {authors, hrefs, isSaved, isHosting, visibility},
   sortBy,
   offset,
   limit,
   reverse
 })
-<span class="hljs-keyword">await</span> statuses.get(url)
 
 <span class="hljs-comment">// write</span>
-<span class="hljs-keyword">await</span> statuses.add({body, visibility})
-<span class="hljs-keyword">await</span> statuses.edit(url, {body, visibility})
-<span class="hljs-keyword">await</span> statuses.remove(url)
+<span class="hljs-keyword">await</span> websites.configure(href, {isSaved, isHosting, visibility})
 </code></pre>
 <hr>
-<h3>Status</h3>
-<p>The values returned by status functions will fit the following object shape:</p>
+<h3>Website</h3>
+<p>The values returned by website functions will fit the following object shape:</p>
 <table>
 <thead>
 <tr>
@@ -102,29 +99,9 @@
 </thead>
 <tbody>
 <tr>
-<td>url</td>
-<td><code>string</code></td>
-<td>The URL of the status</td>
-</tr>
-<tr>
-<td>body</td>
-<td><code>string</code></td>
-<td>The text body of the status</td>
-</tr>
-<tr>
-<td>createdAt</td>
-<td><code>string</code></td>
-<td>The timestamp of when the status claims it was created</td>
-</tr>
-<tr>
-<td>updatedAt</td>
-<td><code>string</code></td>
-<td>The timestamp of when the status claims it was last updated</td>
-</tr>
-<tr>
 <td>author</td>
 <td><code>Object</code></td>
-<td>The status author’s information</td>
+<td>The site that published the website</td>
 </tr>
 <tr>
 <td> url</td>
@@ -147,15 +124,45 @@
 <td></td>
 </tr>
 <tr>
+<td>href</td>
+<td><code>string</code></td>
+<td>The URL of the published website</td>
+</tr>
+<tr>
+<td>title</td>
+<td><code>string</code></td>
+<td>The title of the published website</td>
+</tr>
+<tr>
+<td>description</td>
+<td><code>string</code></td>
+<td>The description of the published website</td>
+</tr>
+<tr>
+<td>isSaved</td>
+<td><code>boolean</code></td>
+<td>Has the local user saved the website? <strong>(private)</strong></td>
+</tr>
+<tr>
+<td>isHosting</td>
+<td><code>boolean</code></td>
+<td>Is the local user hosting the website? <strong>(private)</strong></td>
+</tr>
+<tr>
 <td>visibility</td>
 <td><code>string</code></td>
-<td>The <a href="/docs/common-fields#visibility">visibility</a> of the status</td>
+<td>The <a href="/docs/common-fields#visibility">visibility</a> of the website and its record</td>
 </tr>
 </tbody>
 </table>
+<p>The fields marked <strong>(private)</strong> will only show on the local user’s records.</p>
+<hr>
+<h3>Notes</h3>
+<p>Websites are part of the user’s personal library. The canonical record of a saved website is stored privately. If the visibility is “public” then a link-entry will also be added to the <a href="/links">public Links record</a> at <code>/.data/websites.json</code>.</p>
+<p>Thumbnails of published websites should be published at <code>/.data/thumbs/websites/</code> using the domain name as the filename.</p>
 <hr>
 <h3>list(opts)</h3>
-<p>List the statuses on the network.</p>
+<p>List websites by that are saved locally or published by authors.</p>
 <table>
 <thead>
 <tr>
@@ -182,7 +189,25 @@
 <td>  authors</td>
 <td><code>string|string[]</code></td>
 <td></td>
-<td>Site URLs</td>
+<td>Author-site URLs</td>
+</tr>
+<tr>
+<td>  hrefs</td>
+<td><code>string|string[]</code></td>
+<td></td>
+<td>Website URLs</td>
+</tr>
+<tr>
+<td>  isSaved</td>
+<td><code>boolean</code></td>
+<td></td>
+<td>Has the local user saved the website?</td>
+</tr>
+<tr>
+<td>  isHosting</td>
+<td><code>boolean</code></td>
+<td></td>
+<td>Is the local user hosting the website?</td>
 </tr>
 <tr>
 <td>  visibility</td>
@@ -193,8 +218,8 @@
 <tr>
 <td> sortBy</td>
 <td><code>string</code></td>
-<td><code>'createdAt'</code></td>
-<td>One of: <code>'createdAt'</code></td>
+<td><code>'topic'</code></td>
+<td>One of: <code>'topic'</code></td>
 </tr>
 <tr>
 <td> offset</td>
@@ -224,13 +249,13 @@
 </thead>
 <tbody>
 <tr>
-<td><code>Promise&lt;Status[]&gt;</code></td>
+<td><code>Promise&lt;Website[]&gt;</code></td>
 </tr>
 </tbody>
 </table>
 <hr>
-<h3>get(url)</h3>
-<p>Get an individual status by its URL.</p>
+<h3>configure(href, opts)</h3>
+<p>Configure a website in the local user’s library.</p>
 <table>
 <thead>
 <tr>
@@ -242,146 +267,34 @@
 </thead>
 <tbody>
 <tr>
-<td>url</td>
+<td>href</td>
 <td><code>string</code></td>
 <td></td>
-<td>Status URL (required)</td>
+<td>Website URL (required)</td>
 </tr>
-</tbody>
-</table>
-<table>
-<thead>
 <tr>
-<th>Returns</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>Promise&lt;Status&gt;</code></td>
-</tr>
-</tbody>
-</table>
-<hr>
-<h3>add(status)</h3>
-<p>Add a status to the current user’s site.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Default</th>
-<th>Usage</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>status</td>
-<td><code>string|Object</code></td>
+<td>opts</td>
+<td><code>Object</code></td>
 <td></td>
-<td>If a string, specifies the body (required)</td>
+<td></td>
 </tr>
 <tr>
-<td> body</td>
+<td> isSaved</td>
+<td><code>boolean</code></td>
+<td></td>
+<td>Save the website to the local user’s library?</td>
+</tr>
+<tr>
+<td> isHosting</td>
+<td><code>boolean</code></td>
+<td></td>
+<td>Host the website using the local user’s devices?</td>
+</tr>
+<tr>
+<td> <a href="/docs/common-fields#visibility">visibility</a></td>
 <td><code>string</code></td>
 <td></td>
-<td>The status body (required)</td>
-</tr>
-<tr>
-<td> visibility</td>
-<td><code>string</code></td>
-<td><code>'public'</code></td>
-<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
-</tr>
-</tbody>
-</table>
-<table>
-<thead>
-<tr>
-<th>Returns</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>Promise&lt;Status&gt;</code></td>
-</tr>
-</tbody>
-</table>
-<h4>Example</h4>
-<pre><code class="language-js"><span class="hljs-keyword">await</span> statuses.add(<span class="hljs-string">'Hello, world!'</span>)
-<span class="hljs-keyword">await</span> statuses.add({<span class="hljs-attr">body</span>: <span class="hljs-string">'Hello, me!'</span>, <span class="hljs-attr">visibility</span>: <span class="hljs-string">'private'</span>})
-</code></pre>
-<hr>
-<h3>edit(url, status)</h3>
-<p>Edit a status on the current user’s site.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Default</th>
-<th>Usage</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>url</td>
-<td><code>string</code></td>
-<td></td>
-<td>The URL of the status you want to edit (required)</td>
-</tr>
-<tr>
-<td>status</td>
-<td><code>string|Object</code></td>
-<td></td>
-<td>If a string, specifies the body (required)</td>
-</tr>
-<tr>
-<td> body</td>
-<td><code>string</code></td>
-<td></td>
-<td>The status body (required)</td>
-</tr>
-<tr>
-<td> visibility</td>
-<td><code>string</code></td>
-<td><code>'public'</code></td>
-<td>See <a href="/docs/common-fields#visibility">visibility</a></td>
-</tr>
-</tbody>
-</table>
-<table>
-<thead>
-<tr>
-<th>Returns</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><code>Promise&lt;Status&gt;</code></td>
-</tr>
-</tbody>
-</table>
-<h4>Example</h4>
-<pre><code class="language-js"><span class="hljs-keyword">await</span> statuses.edit(myStatus.url, <span class="hljs-string">'Hello, world!!'</span>)
-</code></pre>
-<hr>
-<h3>remove(url)</h3>
-<p>Delete a status on the current user’s site.</p>
-<table>
-<thead>
-<tr>
-<th>Param</th>
-<th>Type</th>
-<th>Default</th>
-<th>Usage</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>url</td>
-<td><code>string</code></td>
-<td></td>
-<td>The URL of the status you want to remove (required)</td>
+<td>One of: <code>'public'</code>, <code>'unlisted'</code>, <code>'private'</code></td>
 </tr>
 </tbody>
 </table>
@@ -397,7 +310,6 @@
 </tr>
 </tbody>
 </table>
-<hr>
 </main>
     </div>
   </body>

--- a/assets/index.html
+++ b/assets/index.html
@@ -24,10 +24,10 @@
         </div>
         <div class="card code">
           <pre class="card-section">
-<span class="hljs-keyword">import</span> {posts, follows} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
+<span class="hljs-keyword">import</span> {statuses, follows} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
 
 <span class="hljs-keyword">await</span> follows.add(<span class="hljs-string">'dat://beakerbrowser.com'</span>)
-<span class="hljs-keyword">await</span> posts.add(<span class="hljs-string">'Hello, world!'</span>)
+<span class="hljs-keyword">await</span> statuses.add(<span class="hljs-string">'Hello, world!'</span>)
 
 <span class="hljs-comment">/*
  The API wraps the filesystem
@@ -51,10 +51,6 @@
         <div>
           <h3>Can unwalled.garden be used with HTTP?</h3>
           <p>There are no technical barriers to using HTTP, but we haven't completed that implementation yet. We currently use the <a href="https://dat.foundation">Dat protocol</a> because it allows users to publish websites from their own device using p2p networking.</p>
-        </div>
-        <div>
-          <h3>Can I use my own schemas?</h3>
-          <p>Schemas are identified by URLs and so it will be possible for other namespaces to interoperate with unwalled.garden.</p>
         </div>
         <div>
           <h3>Can I add schemas to Unwalled.Garden?</h3>

--- a/assets/nav.html
+++ b/assets/nav.html
@@ -22,6 +22,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -31,6 +32,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/bookmark.html
+++ b/bookmark.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/comment.html
+++ b/comment.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/dir/data.html
+++ b/dir/data.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/dir/data.html
+++ b/dir/data.html
@@ -72,7 +72,7 @@
 <ul>
 <li>Folder type</li>
 <li><strong>Description</strong>: Contains the unwalled.garden record files.</li>
-<li><strong>Path</strong>: <code>/.data/unwalled.garden</code></li>
+<li><strong>Path</strong>: <code>/.data</code></li>
 </ul>
 <hr>
 <h3>File structure</h3>
@@ -85,28 +85,51 @@
 </thead>
 <tbody>
 <tr>
-<td><code>/.data/unwalled.garden/bookmarks/*.json</code></td>
+<td><code>/.data/bookmarks/*.json</code></td>
 <td><a href="/bookmark">Bookmark</a></td>
 </tr>
 <tr>
-<td><code>/.data/unwalled.garden/comments/*.json</code></td>
+<td><code>/.data/comments/*.json</code></td>
 <td><a href="/comment">Comment</a></td>
 </tr>
 <tr>
-<td><code>/.data/unwalled.garden/follows.json</code></td>
+<td><code>/.data/follows.json</code></td>
 <td><a href="/follows">Follows</a></td>
 </tr>
 <tr>
-<td><code>/.data/unwalled.garden/statuses/*.json</code></td>
+<td><code>/.data/statuses/*.json</code></td>
 <td><a href="/status">Status</a></td>
 </tr>
 <tr>
-<td><code>/.data/unwalled.garden/reactions/*.json</code></td>
+<td><code>/.data/reactions/*.json</code></td>
 <td><a href="/reaction">Reaction</a></td>
 </tr>
 <tr>
-<td><code>/.data/unwalled.garden/votes/*.json</code></td>
+<td><code>/.data/thumbs</code></td>
+<td>Images (Thumbnails)</td>
+</tr>
+<tr>
+<td><code>/.data/votes/*.json</code></td>
 <td><a href="/vote">Vote</a></td>
+</tr>
+<tr>
+<td><code>/.data/websites.json</code></td>
+<td><a href="/links">Links</a></td>
+</tr>
+</tbody>
+</table>
+<p>The <code>thumbs</code> folder includes the following structure:</p>
+<table>
+<thead>
+<tr>
+<th>Path</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>/.data/thumbs/websites/*.(png|jpg|jpeg)</code></td>
+<td>For website records</td>
 </tr>
 </tbody>
 </table>

--- a/dir/refs.html
+++ b/dir/refs.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>
@@ -78,9 +80,6 @@
 <h3>Notes</h3>
 <p>The “Refs” directory contains mounts to referenced Dat sites.</p>
 <p>The <code>follows</code> folder is used by the <a href="/follows">follows record</a> as a way to give fast access to the <code>dat.json</code> of followed users.</p>
-<p>The <code>authored</code> folder acts as a listing of sites published by a <a href="/person">person</a>. Readers can create a list of published sites by reading the <code>dat.json</code> of each mounted dat. (There is no JSON record of authored sites; just this .refs directory.)</p>
-<p>The <code>authors</code> folder lists the authors of a non-person site.</p>
-<p>Readers should confirm authorship of sites by looking for the bidirectional authors/authored mounts: the author will be mounted in the <code>.ref/authors</code> of the site, while the site will be listed in the <code>.ref/authored</code> of the author. If this bidirectional mount does not exist, no authorship information should be displayed to the user as it might be a false claim of authorship.</p>
 <p>The names of the mounts in the <code>.ref</code> folders can be user-friendly shortnames. Readers should read the mount target field to find specific sites.</p>
 <h3>File structure</h3>
 <table>
@@ -94,14 +93,6 @@
 <tr>
 <td><code>/.refs/follows/*</code></td>
 <td>Mounts pointing to all followed sites.</td>
-</tr>
-<tr>
-<td><code>/.refs/authored/*</code></td>
-<td>Mounts pointing to all published sites.</td>
-</tr>
-<tr>
-<td><code>/.refs/authors/*</code></td>
-<td>Mounts pointing to the authors of a site.</td>
 </tr>
 </tbody>
 </table>

--- a/docs/browser-integration.html
+++ b/docs/browser-integration.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/docs/common-fields.html
+++ b/docs/common-fields.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>
@@ -69,18 +71,19 @@
       </nav>
       <main><h2>Common fields</h2>
 <h3><span id="visibility">visibility</span></h3>
-<p>The <var>visibility</var> field indicates who will be given access to the record. It currently has two possible values:</p>
+<p>The <var>visibility</var> field indicates who will be given access to some information. It currently has three possible values:</p>
 <ul>
-<li><code>'private'</code> The record is only accessible on the local user’s devices. It is not shared with anyone.</li>
-<li><code>'public'</code> The record is published publicly and can be accessed by anyone.</li>
+<li><code>'private'</code> The info is only accessible on the local user’s devices. It is not shared with anyone.</li>
+<li><code>'unlisted'</code> The info is accessible on the network by anyone but has not been published on the author’s site.</li>
+<li><code>'public'</code> The info is published publicly and can be accessed by anyone.</li>
 </ul>
 <p>When used as a query parameter, the field can also have the following value:</p>
 <ul>
-<li><code>'all'</code> Include both private and public records.</li>
+<li><code>'all'</code> Include all kinds of records.</li>
 </ul>
 <h4>How does it work?</h4>
 <p>A user has two Dat hyperdrives: a public and a private. They both possess the <a href="/dir/data">Data directory</a> in roughly the same location. In <a href="https://beakerbrowser.com">Beaker</a>, the private drive acts as the “root” of the user’s filesystem, and the public drive is <a href="/docs/mounts">mounted</a> to <code>/public</code> on the private drive.</p>
-<p>The private drive is kept off the network. When <var>visibility</var> is set to <code>'private'</code>, the record is written there. When set to <code>'public'</code>, it’s written to the public drive.</p>
+<p>The private drive is kept off the network. When <var>visibility</var> is set to <code>'private'</code>, the record is written there. When set to <code>'public'</code>, it’s written to the public drive. The <code>'unlisted'</code> value typically applies to separate dats that the user has created (such as <a href="/api/websites">Websites</a>).</p>
 </main>
     </div>
   </body>

--- a/docs/dat-primer.html
+++ b/docs/dat-primer.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/docs/how-does-it-work.html
+++ b/docs/how-does-it-work.html
@@ -99,19 +99,19 @@
 <td><a href="/person">Person</a></td>
 </tr>
 <tr>
-<td><code>dat://bob.com/.data/unwalled.garden</code></td>
+<td><code>dat://bob.com/.data</code></td>
 <td><a href="/dir/data">Data directory</a></td>
 </tr>
 <tr>
-<td><code>dat://bob.com/.data/unwalled.garden/statuses/hello.json</code></td>
+<td><code>dat://bob.com/.data/statuses/hello.json</code></td>
 <td><a href="/status">Status</a></td>
 </tr>
 <tr>
-<td><code>dat://bob.com/.data/unwalled.garden/reactions/1.json</code></td>
+<td><code>dat://bob.com/.data/reactions/1.json</code></td>
 <td><a href="/reaction">Reaction</a></td>
 </tr>
 <tr>
-<td><code>dat://bob.com/.data/unwalled.garden/comments/1.json</code></td>
+<td><code>dat://bob.com/.data/comments/1.json</code></td>
 <td><a href="/comment">Comment</a></td>
 </tr>
 </tbody>

--- a/docs/how-does-it-work.html
+++ b/docs/how-does-it-work.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/docs/mounts.html
+++ b/docs/mounts.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/docs/why-not-rdf.html
+++ b/docs/why-not-rdf.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/follows.html
+++ b/follows.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -69,6 +70,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/index.html
+++ b/index.html
@@ -24,10 +24,10 @@
         </div>
         <div class="card code">
           <pre class="card-section">
-<span class="hljs-keyword">import</span> {posts, follows} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
+<span class="hljs-keyword">import</span> {statuses, follows} <span class="hljs-keyword">from</span> <span class="hljs-string">'dat://unwalled.garden/index.js'</span>
 
 <span class="hljs-keyword">await</span> follows.add(<span class="hljs-string">'dat://beakerbrowser.com'</span>)
-<span class="hljs-keyword">await</span> posts.add(<span class="hljs-string">'Hello, world!'</span>)
+<span class="hljs-keyword">await</span> statuses.add(<span class="hljs-string">'Hello, world!'</span>)
 
 <span class="hljs-comment">/*
  The API wraps the filesystem
@@ -103,10 +103,6 @@
         <div>
           <h3>Can unwalled.garden be used with HTTP?</h3>
           <p>There are no technical barriers to using HTTP, but we haven't completed that implementation yet. We currently use the <a href="https://dat.foundation">Dat protocol</a> because it allows users to publish websites from their own device using p2p networking.</p>
-        </div>
-        <div>
-          <h3>Can I use my own schemas?</h3>
-          <p>Schemas are identified by URLs and so it will be possible for other namespaces to interoperate with unwalled.garden.</p>
         </div>
         <div>
           <h3>Can I add schemas to Unwalled.Garden?</h3>

--- a/links.html
+++ b/links.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <head>
-    <title>Vote (unwalled.garden/vote) | Unwalled.Garden</title>
+    <title>Links (unwalled.garden/links) | Unwalled.Garden</title>
     <meta charset="utf-8">
     <link rel="stylesheet" href="/assets/styles.css">
     <link rel="stylesheet" href="/assets/syntax.css">
@@ -69,56 +69,67 @@
   </li>
 </ul>
       </nav>
-      <main><h2>Vote <code>unwalled.garden/vote</code></h2>
+      <main><h2>Links <code>unwalled.garden/links</code></h2>
 <hr>
 <ul>
 <li>File type</li>
-<li><strong>Description</strong>: A vote up or down on some resource.</li>
-<li><strong>Path</strong>: <code>/.data/unwalled.garden/votes/*.json</code></li>
+<li><strong>Description</strong>: A list of links.</li>
 </ul>
 <hr>
+<h4>Notes</h4>
+<p>This is a general-purpose schema that can be used in a number of different contexts.<br>
+For example, the <a href="/api/websites">Websites API</a> uses it to list published websites at <code>/.data/websites.json</code>.</p>
 <h4>Example</h4>
 <pre><code class="language-json">{
-  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/vote"</span>,
-  <span class="hljs-attr">"topic"</span>: <span class="hljs-string">"dat://beakerbrowser.com"</span>,
-  <span class="hljs-attr">"vote"</span>: <span class="hljs-number">1</span>,
-  <span class="hljs-attr">"createdAt"</span>: <span class="hljs-string">"2018-12-07T02:52:11.947Z"</span>
+  <span class="hljs-attr">"type"</span>: <span class="hljs-string">"unwalled.garden/links"</span>,
+  <span class="hljs-attr">"links"</span>: [
+    {
+      <span class="hljs-attr">"href"</span>: <span class="hljs-string">"dat://pfrazee.com"</span>,
+      <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Paul Frazee"</span>,
+      <span class="hljs-attr">"description"</span>: <span class="hljs-string">"Beaker guy"</span>,
+    },
+    {
+      <span class="hljs-attr">"href"</span>: <span class="hljs-string">"dat://43dfc9f23fdded8cc7c01c71c0702a0529130af0258e7fb30bf5a0a3f73d69b3"</span>,
+      <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Unwalled Garden"</span>
+    }
+  ]
 }
 </code></pre>
 <h4>Schema</h4>
 <pre><code class="language-json">{
   <span class="hljs-attr">"$schema"</span>: <span class="hljs-string">"http://json-schema.org/draft-07/schema#"</span>,
-  <span class="hljs-attr">"$id"</span>: <span class="hljs-string">"dat://unwalled.garden/vote.json"</span>,
+  <span class="hljs-attr">"$id"</span>: <span class="hljs-string">"dat://unwalled.garden/links.json"</span>,
   <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
-  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Vote"</span>,
-  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A vote up or down on some resource."</span>,
+  <span class="hljs-attr">"title"</span>: <span class="hljs-string">"Links"</span>,
+  <span class="hljs-attr">"description"</span>: <span class="hljs-string">"A list of links."</span>,
   <span class="hljs-attr">"required"</span>: [
     <span class="hljs-string">"type"</span>,
-    <span class="hljs-string">"topic"</span>,
-    <span class="hljs-string">"vote"</span>,
-    <span class="hljs-string">"createdAt"</span>
+    <span class="hljs-string">"links"</span>
   ],
   <span class="hljs-attr">"properties"</span>: {
     <span class="hljs-attr">"type"</span>: {
       <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
       <span class="hljs-attr">"description"</span>: <span class="hljs-string">"The object's type"</span>,
-      <span class="hljs-attr">"const"</span>: <span class="hljs-string">"unwalled.garden/vote"</span>
+      <span class="hljs-attr">"const"</span>: <span class="hljs-string">"unwalled.garden/links"</span>
     },
-    <span class="hljs-attr">"topic"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>
-    },
-    <span class="hljs-attr">"vote"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"number"</span>,
-      <span class="hljs-attr">"enum"</span>: [<span class="hljs-number">-1</span>, <span class="hljs-number">1</span>]
-    },
-    <span class="hljs-attr">"createdAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>,
-    },
-    <span class="hljs-attr">"updatedAt"</span>: {
-      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
-      <span class="hljs-attr">"format"</span>: <span class="hljs-string">"date-time"</span>
+    <span class="hljs-attr">"links"</span>: {
+      <span class="hljs-attr">"type"</span>: <span class="hljs-string">"array"</span>,
+      <span class="hljs-attr">"items"</span>: {
+        <span class="hljs-attr">"type"</span>: <span class="hljs-string">"object"</span>,
+        <span class="hljs-attr">"required"</span>: [<span class="hljs-string">"href"</span>],
+        <span class="hljs-attr">"properties"</span>: {
+          <span class="hljs-attr">"href"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>,
+            <span class="hljs-attr">"format"</span>: <span class="hljs-string">"uri"</span>
+          },
+          <span class="hljs-attr">"title"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          },
+          <span class="hljs-attr">"description"</span>: {
+            <span class="hljs-attr">"type"</span>: <span class="hljs-string">"string"</span>
+          }
+        }
+      }
     }
   }
 }

--- a/links.json
+++ b/links.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "dat://unwalled.garden/links.json",
+  "type": "object",
+  "title": "Links",
+  "description": "A list of links.",
+  "required": [
+    "type",
+    "links"
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "description": "The object's type",
+      "const": "unwalled.garden/links"
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["href"],
+        "properties": {
+          "href": {
+            "type": "string",
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/person.html
+++ b/person.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/person.html
+++ b/person.html
@@ -124,16 +124,12 @@
 <td>Profile picture</td>
 </tr>
 <tr>
-<td><code>/.data/unwalled.garden</code></td>
+<td><code>/.data</code></td>
 <td><a href="/dir/data">Data directory</a></td>
 </tr>
 <tr>
-<td><code>/.refs/follows</code></td>
-<td><a href="/dir/refs">Refs “followed sites” directory</a></td>
-</tr>
-<tr>
-<td><code>/.refs/authored</code></td>
-<td><a href="/dir/refs">Refs “authored sites” directory</a></td>
+<td><code>/.refs</code></td>
+<td><a href="/dir/refs">Refs directory</a></td>
 </tr>
 </tbody>
 </table>

--- a/reaction.html
+++ b/reaction.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>

--- a/status.html
+++ b/status.html
@@ -37,6 +37,7 @@
       <li><a href="/api/statuses">Statuses</a></li>
       <li><a href="/api/reactions">Reactions</a></li>
       <li><a href="/api/votes">Votes</a></li>
+      <li><a href="/api/websites">Websites</a></li>
     </ul>
   </li>
 </ul>
@@ -46,6 +47,7 @@
       <li><a href="/bookmark">Bookmark</a></li>
       <li><a href="/comment">Comment</a></li>
       <li><a href="/follows">Follows</a></li>
+      <li><a href="/links">Links</a></li>
       <li><a href="/person">Person</a></li>
       <li><a href="/status">Status</a></li>
       <li><a href="/reaction">Reaction</a></li>


### PR DESCRIPTION
Bad form to group 2 changes into one PR but it's shiptember, I'm on the move

## Websites API and Links Schema

The Websites API gives read/write control over the local user's library of Dat Websites. It also gives read access to the public network of Dat Websites (as indexed from followed users).

The "Links" schema is a generic way to store a collection of links. In the `/.data/websites.json` case it lists the user's published websites.

## Files restructure

"Typed dats" are going to feature much more prominently in Beaker than I originally expected -- to the extent that most typed dats will trigger the user's viewer applications rather than running the HTML/CSS/JS within the dat. In the case of the Person type, for instance, the Person Viewer will run. The upsides of this are many, but the biggest upside is that viewer-apps are trusted and so can access the UwG APIs without asking permission. This helps create a UwG Web where you can navigate to data and see the correct interface -- effectively separating content and presentation as the Web first intended.

The Viewer Application is chosen based on the dat type. This means that the dat's data really needs to be understood by the Viewer and putting non unwalled.garden schemas in the dat won't work as well. So: I'm denamespacing the data folders and instead going to use subdats for other types of information.

In effect, this means the folder structure is changing from

````
/.data/unwalled.garden/statuses
/.data/unwalled.garden/comments
etc
```

to


```
/.data/statuses
/.data/comments
etc
```